### PR TITLE
Append default API endpoint to docs for GHE

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Github Enterprise support
 * Making a request:
 
   ```lisp
-  (let ((ghub-base-url "https://gh.example.com"))
+  (let ((ghub-base-url "https://gh.example.com/api/v3"))
     (ghub-get "/users/employee/repos"))
   ```
 


### PR DESCRIPTION
Enterprise instances have a default API endpoint of the hostname with the suffix `/api/v3`. Add this to the docs for n00bs like me.