### PR TITLE
Improve docs on manually creating tokens

### DIFF
--- a/ghub.el
+++ b/ghub.el
@@ -1,6 +1,6 @@
 ;;; ghub.el --- minuscule client library for the Github API  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2016-2017  Jonas Bernoulli
+;; Copyright (C) 2016-2018  Jonas Bernoulli
 
 ;; Author: Jonas Bernoulli <jonas@bernoul.li>
 ;; Homepage: https://github.com/magit/ghub

--- a/ghub.el
+++ b/ghub.el
@@ -529,7 +529,8 @@ has to provide several values including their password."
 WARNING: If you have enabled two-factor authentication then
          you have to abort and create the token manually.
 
-If in doubt, then abort and view the documentation first.
+If in doubt, then abort and first view the section of the Ghub
+documentation called \"Manually Creating and Storing a Token\".
 
 Otherwise confirm and then provide your Github username and
 password at the next two prompts.  Depending on the backend

--- a/ghub.org
+++ b/ghub.org
@@ -7,7 +7,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Ghub: (ghub).
 #+TEXINFO_DIR_DESC: Minuscule client library for the Github API.
-#+SUBTITLE: for version 1.3.0 (v1.3.0-35-g5226d51+1)
+#+SUBTITLE: for version 1.3.0 (v1.3.0-36-gca466a0+1)
 #+BIND: ox-texinfo+-before-export-hook ox-texinfo+-update-version-strings
 
 #+TEXINFO_DEFFN: t
@@ -31,7 +31,7 @@ because then all packages that talk to the Github API could be
 configured the same way.
 
 #+TEXINFO: @noindent
-This manual is for Ghub version 1.3.0 (v1.3.0-35-g5226d51+1).
+This manual is for Ghub version 1.3.0 (v1.3.0-36-gca466a0+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2017-2018 Jonas Bernoulli <jonas@bernoul.li>
@@ -231,7 +231,8 @@ then the setup wizard will first ask you something like this:
   WARNING: If you have enabled two-factor authentication
            then you have to create the token manually.
 
-  If in doubt, then abort and view the documentation first.
+  If in doubt, then abort and first view the section of the Ghub
+  documentation called "Manually Creating and Storing a Token".
 
   Create and store such a token? (yes or no)
 #+END_EXAMPLE

--- a/ghub.org
+++ b/ghub.org
@@ -1,13 +1,13 @@
 #+TITLE: Ghub User and Developer Manual
 #+AUTHOR: Jonas Bernoulli
 #+EMAIL: jonas@bernoul.li
-#+DATE: 2017
+#+DATE: 2017-2018
 #+LANGUAGE: en
 
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Ghub: (ghub).
 #+TEXINFO_DIR_DESC: Minuscule client library for the Github API.
-#+SUBTITLE: for version 1.3.0 (v1.3.0-31-g6443c4f+1)
+#+SUBTITLE: for version 1.3.0 (v1.3.0-34-g1395d56+1)
 #+BIND: ox-texinfo+-before-export-hook ox-texinfo+-update-version-strings
 
 #+TEXINFO_DEFFN: t
@@ -31,10 +31,10 @@ because then all packages that talk to the Github API could be
 configured the same way.
 
 #+TEXINFO: @noindent
-This manual is for Ghub version 1.3.0 (v1.3.0-31-g6443c4f+1).
+This manual is for Ghub version 1.3.0 (v1.3.0-34-g1395d56+1).
 
 #+BEGIN_QUOTE
-Copyright (C) 2017 Jonas Bernoulli <jonas@bernoul.li>
+Copyright (C) 2017-2018 Jonas Bernoulli <jonas@bernoul.li>
 
 You can redistribute this document and/or modify it under the terms
 of the GNU General Public License as published by the Free Software
@@ -749,7 +749,7 @@ local machine, which is done using a lisp variable.
 :END:
 
 #+BEGIN_QUOTE
-Copyright (C) 2017 Jonas Bernoulli <jonas@bernoul.li>
+Copyright (C) 2017-2018 Jonas Bernoulli <jonas@bernoul.li>
 
 You can redistribute this document and/or modify it under the terms
 of the GNU General Public License as published by the Free Software

--- a/ghub.org
+++ b/ghub.org
@@ -7,7 +7,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Ghub: (ghub).
 #+TEXINFO_DIR_DESC: Minuscule client library for the Github API.
-#+SUBTITLE: for version 1.3.0 (v1.3.0-34-g1395d56+1)
+#+SUBTITLE: for version 1.3.0 (v1.3.0-35-g5226d51+1)
 #+BIND: ox-texinfo+-before-export-hook ox-texinfo+-update-version-strings
 
 #+TEXINFO_DEFFN: t
@@ -31,7 +31,7 @@ because then all packages that talk to the Github API could be
 configured the same way.
 
 #+TEXINFO: @noindent
-This manual is for Ghub version 1.3.0 (v1.3.0-34-g1395d56+1).
+This manual is for Ghub version 1.3.0 (v1.3.0-35-g5226d51+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2017-2018 Jonas Bernoulli <jonas@bernoul.li>
@@ -344,7 +344,7 @@ variables should document what the various scopes are needed for.
 
 To create or edit a token go to https://github.com/settings/tokens.
 
-Finally store the token in a place where Ghub looks for it as describe
+Finally store the token in a place where Ghub looks for it, as described
 in [[*How Ghub uses Auth-Source]].
 
 ** How Ghub uses Auth-Source

--- a/ghub.texi
+++ b/ghub.texi
@@ -30,7 +30,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Ghub User and Developer Manual
-@subtitle for version 1.3.0 (v1.3.0-34-g1395d56+1)
+@subtitle for version 1.3.0 (v1.3.0-35-g5226d51+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -61,7 +61,7 @@ because then all packages that talk to the Github API could be
 configured the same way.
 
 @noindent
-This manual is for Ghub version 1.3.0 (v1.3.0-34-g1395d56+1).
+This manual is for Ghub version 1.3.0 (v1.3.0-35-g5226d51+1).
 
 @quotation
 Copyright (C) 2017-2018 Jonas Bernoulli <jonas@@bernoul.li>
@@ -451,7 +451,7 @@ variables should document what the various scopes are needed for.
 
 To create or edit a token go to @uref{https://github.com/settings/tokens}.
 
-Finally store the token in a place where Ghub looks for it as describe
+Finally store the token in a place where Ghub looks for it, as described
 in @ref{How Ghub uses Auth-Source}.
 
 @node How Ghub uses Auth-Source

--- a/ghub.texi
+++ b/ghub.texi
@@ -30,7 +30,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Ghub User and Developer Manual
-@subtitle for version 1.3.0 (v1.3.0-35-g5226d51+1)
+@subtitle for version 1.3.0 (v1.3.0-36-gca466a0+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -61,7 +61,7 @@ because then all packages that talk to the Github API could be
 configured the same way.
 
 @noindent
-This manual is for Ghub version 1.3.0 (v1.3.0-35-g5226d51+1).
+This manual is for Ghub version 1.3.0 (v1.3.0-36-gca466a0+1).
 
 @quotation
 Copyright (C) 2017-2018 Jonas Bernoulli <jonas@@bernoul.li>
@@ -324,7 +324,8 @@ Such a Github API token is not available:
 WARNING: If you have enabled two-factor authentication
          then you have to create the token manually.
 
-If in doubt, then abort and view the documentation first.
+If in doubt, then abort and first view the section of the Ghub
+documentation called "Manually Creating and Storing a Token".
 
 Create and store such a token? (yes or no)
 @end example

--- a/ghub.texi
+++ b/ghub.texi
@@ -8,7 +8,7 @@
 
 @copying
 @quotation
-Copyright (C) 2017 Jonas Bernoulli <jonas@@bernoul.li>
+Copyright (C) 2017-2018 Jonas Bernoulli <jonas@@bernoul.li>
 
 You can redistribute this document and/or modify it under the terms
 of the GNU General Public License as published by the Free Software
@@ -30,7 +30,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Ghub User and Developer Manual
-@subtitle for version 1.3.0 (v1.3.0-31-g6443c4f+1)
+@subtitle for version 1.3.0 (v1.3.0-34-g1395d56+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -61,10 +61,10 @@ because then all packages that talk to the Github API could be
 configured the same way.
 
 @noindent
-This manual is for Ghub version 1.3.0 (v1.3.0-31-g6443c4f+1).
+This manual is for Ghub version 1.3.0 (v1.3.0-34-g1395d56+1).
 
 @quotation
-Copyright (C) 2017 Jonas Bernoulli <jonas@@bernoul.li>
+Copyright (C) 2017-2018 Jonas Bernoulli <jonas@@bernoul.li>
 
 You can redistribute this document and/or modify it under the terms
 of the GNU General Public License as published by the Free Software


### PR DESCRIPTION
If an emacs user who has two-factor authentication enabled on GitHub installs magithub, they'll see a message from Ghub telling them to read the documentation for how to set up a token manually, but they might not even have heard about Ghub at this point, let alone know that this message is referring them to its docs.

So make it clear to the user where they should look.

Also fix a typo.

**Please note:** I assume that the `.texi` file is auto-generated from the `.org` file but I didn't have time to check; I just hand-edited both.  I haven't checked the rendered versions either - sorry but very short on time.