### PR TITLE
Basic Gitlab support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Minuscule client library for the Github API
-===========================================
+Ghub.el — Minuscule client library for the Github API
+=====================================================
 
 Ghub is a library that provides basic support for using the Github API
 from Emacs packages.  It abstracts access to API resources using only
@@ -18,4 +18,20 @@ wide adoption would make life easier for users and maintainers alike,
 because then all packages that talk to the Github API could be
 configured the same way.
 
-Consulting the [manual](https://magit.vc/manual/ghub) can be beneficial.
+Please consult the [manual][manual-ghub] for more information.
+
+Glab.el — Minuscule client library for the Gitlab API
+=====================================================
+
+Glab is a library that provides basic support for using the Gitlab API
+from Emacs packages.  It abstracts access to API resources using only
+a handful of functions that are not resource-specific.
+
+This library is implemented on top of Ghub.  Unlike Ghub, Glab does
+not support the guided creation of tokens because Gitlab lacks the
+features that would be necessary to implement that.  Users have to
+create tokens through the web interface.  Instructions can be found
+[here][manual-glab].
+
+[manual-ghub]: https://magit.vc/manual/ghub
+[manual-glab]: https://magit.vc/manual/ghub/Gitlab-Support.html

--- a/ghub.el
+++ b/ghub.el
@@ -166,14 +166,16 @@ Like calling `ghub-request' (which see) with \"DELETE\" as METHOD."
 (define-error 'ghub-401 "Unauthorized" 'ghub-http-error)
 (define-error 'ghub-403 "Forbidden" 'ghub-http-error)
 (define-error 'ghub-404 "Not Found" 'ghub-http-error)
+(define-error 'ghub-405 "Method Not Allowed" 'ghub-http-error) ; gitlab only
 (define-error 'ghub-409 "Conflict" 'ghub-http-error)
+(define-error 'ghub-412 "Precondition Failed" 'ghub-http-error) ; gitlab only
 (define-error 'ghub-422 "Unprocessable Entity" 'ghub-http-error)
 (define-error 'ghub-500 "Internal Server Error" 'ghub-http-error)
 
 (cl-defun ghub-request (method resource &optional params
                                &key query payload headers
                                unpaginate noerror reader
-                               username auth host)
+                               username auth host forge)
   "Make a request for RESOURCE and return the response body.
 
 Also place the response header in `ghub-response-headers'.
@@ -239,11 +241,16 @@ If HOST is non-nil, then connect to that Github instance.  This
   defaults to \"api.github.com\".  When a repository is connected
   to a Github Enterprise instance, then it is better to specify
   that using the Git variable `github.host' instead of using this
-  argument."
+  argument.
+
+If FORGE is `gitlab', then connect to Gitlab.com or, depending
+  on HOST to another Gitlab instance.  This is only intended for
+  internal use.  Instead of using this argument you should use
+  function `glab-request' and other `glab-*' functions."
   (unless (string-prefix-p "/" resource)
     (setq resource (concat "/" resource)))
   (unless host
-    (setq host (ghub--host)))
+    (setq host (ghub--host forge)))
   (cond
    ((not params))
    ((memq method '("GET" "HEAD"))
@@ -262,7 +269,7 @@ If HOST is non-nil, then connect to that Github instance.  This
          (buf (let ((url-request-extra-headers
                      `(("Content-Type" . "application/json")
                        ,@(and (not (eq auth 'none))
-                              (list (ghub--auth host auth username)))
+                              (list (ghub--auth host auth username forge)))
                        ,@headers))
                     ;; Encode in case caller used (symbol-name 'GET).  #35
                     (url-request-method (encode-coding-string method 'utf-8))
@@ -293,7 +300,9 @@ If HOST is non-nil, then connect to that Github instance.  This
             (goto-char (1+ url-http-end-of-headers))
             (setq body (funcall (or reader 'ghub--read-json-response)
                                 url-http-response-status))
-            (unless (or noerror (= (/ url-http-response-status 100) 2))
+            (unless (or noerror
+                        (= (/ url-http-response-status 100) 2)
+                        (= url-http-response-status 304)) ; gitlab only
               (let ((data (list method resource qry payload body)))
                 (pcase url-http-response-status
                   (301 (signal 'ghub-301 data))
@@ -301,7 +310,9 @@ If HOST is non-nil, then connect to that Github instance.  This
                   (401 (signal 'ghub-401 data))
                   (403 (signal 'ghub-403 data))
                   (404 (signal 'ghub-404 data))
+                  (405 (signal 'ghub-405 data)) ; gitlab only
                   (409 (signal 'ghub-409 data))
+                  (412 (signal 'ghub-412 data)) ; gitlab only
                   (422 (signal 'ghub-422 data))
                   (500 (signal 'ghub-500 data))
                   (_   (signal 'ghub-http-error
@@ -450,19 +461,23 @@ has to provide several values including their password."
 
 ;;;; Internal
 
-(defun ghub--auth (host auth &optional username)
+(defun ghub--auth (host auth &optional username forge)
   (unless username
     (setq username (ghub--username host)))
   (if (eq auth 'basic)
-      (cons "Authorization" (ghub--basic-auth host username))
-    (cons "Authorization"
+      (if (eq forge 'gitlab)
+          (error "Gitlab does not support basic authentication")
+        (cons "Authorization" (ghub--basic-auth host username)))
+    (cons (if (eq forge 'gitlab)
+              "Private-Token"
+            "Authorization")
           (concat
-           "token "
+           (and (not (eq forge 'gitlab)) "token ")
            (encode-coding-string
             (cl-typecase auth
               (string auth)
-              (null   (ghub--token host username 'ghub))
-              (symbol (ghub--token host username auth))
+              (null   (ghub--token host username 'ghub nil forge))
+              (symbol (ghub--token host username auth  nil forge))
               (t (signal 'wrong-type-argument
                          `((or stringp symbolp) ,auth))))
             'utf-8)))))
@@ -472,7 +487,7 @@ has to provide several values including their password."
     (setf (url-user url) username)
     (url-basic-auth url t)))
 
-(defun ghub--token (host username package &optional nocreate)
+(defun ghub--token (host username package &optional nocreate forge)
   (let ((user (ghub--ident username package)))
     (or (ghub--auth-source-get :secret :host host :user user)
         (progn
@@ -484,16 +499,25 @@ has to provide several values including their password."
           (auth-source-forget (list :max 1 :host host :user
           user))
           (and (not nocreate)
-               (ghub--confirm-create-token host username package))))))
+               (if (eq forge 'gitlab)
+                   (error
+                    (concat "Required Gitlab token does not exist.  See "
+                            "https://magit.vc/manual/ghub/Gitlab-Support.html "
+                            "for instructions."))
+                 (ghub--confirm-create-token host username package)))))))
 
-(defun ghub--host ()
-  (or (ignore-errors (car (process-lines "git" "config" "github.host")))
-      ghub-default-host))
+(defun ghub--host (&optional forge)
+  (if (eq forge 'gitlab)
+      (or (ignore-errors (car (process-lines "git" "config" "gitlab.host")))
+          (bound-and-true-p glab-default-host))
+    (or (ignore-errors (car (process-lines "git" "config" "github.host")))
+        ghub-default-host)))
 
-(defun ghub--username (host)
-  (let ((var (if (string-prefix-p "api.github.com" host)
-                 "github.user"
-               (format "github.%s.user" host))))
+(defun ghub--username (host &optional forge)
+  (let ((var (cond ((string-prefix-p "api.github.com" host) "github.user")
+                   ((string-prefix-p "gitlab.com/api" host) "gitlab.user")
+                   ((eq forge 'gitlab)     (format "gitlab.%s.user" host))
+                   (t                      (format "github.%s.user" host)))))
     (condition-case nil
         (car (process-lines "git" "config" var))
       (error

--- a/ghub.org
+++ b/ghub.org
@@ -7,7 +7,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Ghub: (ghub).
 #+TEXINFO_DIR_DESC: Minuscule client library for the Github API.
-#+SUBTITLE: for version 1.3.0 (v1.3.0-43-gdabe8ac+1)
+#+SUBTITLE: for version 1.3.0 (v1.3.0-45-g74b577e+1)
 #+BIND: ox-texinfo+-before-export-hook ox-texinfo+-update-version-strings
 
 #+TEXINFO_DEFFN: t
@@ -31,7 +31,7 @@ because then all packages that talk to the Github API could be
 configured the same way.
 
 #+TEXINFO: @noindent
-This manual is for Ghub version 1.3.0 (v1.3.0-43-gdabe8ac+1).
+This manual is for Ghub version 1.3.0 (v1.3.0-45-g74b577e+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2017-2018 Jonas Bernoulli <jonas@bernoul.li>
@@ -109,6 +109,10 @@ don't assume that they don't):
 
 - Support for token scope validation.
 
+- Support for Gitlab is implemented in the ~glab.el~ library, which is
+  maintained in the same repository as ~ghub.el~ but distributed as a
+  separate package.
+
 These features will likely never be implemented in Ghub:
 
 - Functions for particular resources.
@@ -137,14 +141,6 @@ These features are not supported yet:
   that it previously did not need.  I am not quite sure yet whether
   Ghub should support that.  An alternative would be to let packages
   at least invalidate their own tokens.
-
-- Other Git forges (Gitlab, Bitbucket...) are not supported.
-
-  Support for other forges will likely be implemented using *other*
-  libraries that are very similar to this library.  Whether common
-  code will be factored out into a library to be used by all these
-  libraries or whether some code duplication is to be preferred, has
-  not been decided yet.
 
 * Getting Started
 
@@ -342,6 +338,7 @@ variable named ~PACKAGE-ghub-token-scopes~.  The doc-string of such
 variables should document what the various scopes are needed for.
 
 To create or edit a token go to https://github.com/settings/tokens.
+For Gitlab.com use https://gitlab.com/profile/personal_access_tokens.
 
 Finally store the token in a place where Ghub looks for it, as described
 in [[*How Ghub uses Auth-Source]].
@@ -373,11 +370,19 @@ those three slots, and it does that by using "USERNAME^PACKAGE" as the
 "login".
 
 Assuming your username is "ziggy",the package is named "stardust", and
-you want to access Github.com an entry in one of the three mentioned
+you want to access *Github.com* an entry in one of the three mentioned
 files would then look like this:
 
 #+BEGIN_SRC example
   machine api.github.com login ziggy^stardust password 012345abcdef...
+#+END_SRC
+
+Assuming your username is "ziggy",the package is named "stardust", and
+you want to access *Gitlab.com* an entry in one of the three mentioned
+files would then look like this:
+
+#+BEGIN_SRC example
+  machine gitlab.com/api/v4 login ziggy^stardust password 012345abcdef...
 #+END_SRC
 
 * Using Ghub in Personal Scripts
@@ -554,6 +559,11 @@ latter is documented at https://developer.github.com/v3.
     defaults to "api.github.com".  When a repository is connected to
     a Github Enterprise instance, then it is better to specify that
     using the Git variable ~github.host~ instead of using this argument.
+
+  - If FORGE is ~gitlab~, then connect to Gitlab.com or, depending on
+    HOST to another Gitlab instance.  This is only intended for
+    internal use.  Instead of using this argument you should use
+    function ~glab-request~ and other ~glab-*~ functions.
 
 - Variable: ghub-response-headers
 
@@ -747,6 +757,40 @@ local machine, which is done using a lisp variable.
   then be used to identify the local machine instead of the value
   returned by ~system-name~.
 
+* Gitlab Support
+
+Support for Gitlab.com and other Gitlab instances is implemented in
+the library ~glab.el~.  This library is build on top of ~ghub.el~ and is
+maintained in the same repository, but it is distributed as a separate
+package.
+
+When accessing Gitlab.com or another Gitlab instance, use ~glab-request~
+instead of ~ghub-request~, ~glab-get~ instead of ~ghub-request~, etc.
+Likewise use the Git variables in the ~gitlab~ group instead of those in
+the ~github~ group, i.e.  ~gitlab.user~, ~gitlab.HOST.user~ and ~gitlab.host~.
+
+The Gitlab API cannot be used to create tokens, so Glab cannot provide
+a setup wizard like Ghub does.  As a consequence if the user makes a
+request and the necessary token cannot be found, then that results in
+an error.
+
+You have to manually create and store the necessary tokens.  Tokens
+can be created at https://gitlab.com/profile/personal_access_tokens,
+or the equivalent URL for another Gitlab instance.  To store the token
+locally, follow the instructions in [[*Manually Creating and Storing a
+Token]] and [[*How Ghub uses Auth-Source]].
+
+Packages can that use Glab, can define ~PACKAGE-gitlab-token-scopes~ for
+documentation purposes.  But unlike ~PACKAGE-github-token-scopes~, which
+is used by the setup wizard this is optional.
+
+And a random hint: where you would use ~user/repo~ when accessing Github,
+you have to use ~user%2Frepo~ when accessing Gitlab, e.g.:
+
+#+BEGIN_SRC emacs-lisp
+  (glab-get "/projects/python-mode-devs%2Fpython-mode")
+#+END_SRC
+
 * _ Copying
 :PROPERTIES:
 :COPYING:    t
@@ -768,12 +812,12 @@ General Public License for more details.
 
 * _ :ignore:
 
-#  LocalWords:  ARGS AUTH Bitbucket DEFFN DESC EVAL Auth Ghub
-#  LocalWords:  GraphQL LocalWords Makefile NOERROR PARAMS
+#  LocalWords:  ARGS AUTH Bitbucket DEFFN DESC EVAL Auth Ghub Github
+#  LocalWords:  Gitlab Glab GraphQL LocalWords Makefile NOERROR PARAMS
 #  LocalWords:  SRC UNPAGINATE alist alists api auth authinfo
 #  LocalWords:  backend backends config customizable eval
-#  LocalWords:  featurep ghub github hostname http json mis
-#  LocalWords:  netrc noerror num params repo src texinfo toc
+#  LocalWords:  featurep ghub github glab gitlab hostname http json
+#  LocalWords:  mis netrc noerror num params repo src texinfo toc
 #  LocalWords:  unencrypted unpaginate utils ziggy
 
 # IMPORTANT: Also update ORG_ARGS and ORG_EVAL in the Makefile.

--- a/ghub.texi
+++ b/ghub.texi
@@ -30,7 +30,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Ghub User and Developer Manual
-@subtitle for version 1.3.0 (v1.3.0-43-gdabe8ac+1)
+@subtitle for version 1.3.0 (v1.3.0-45-g74b577e+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -61,7 +61,7 @@ because then all packages that talk to the Github API could be
 configured the same way.
 
 @noindent
-This manual is for Ghub version 1.3.0 (v1.3.0-43-gdabe8ac+1).
+This manual is for Ghub version 1.3.0 (v1.3.0-45-g74b577e+1).
 
 @quotation
 Copyright (C) 2017-2018 Jonas Bernoulli <jonas@@bernoul.li>
@@ -85,6 +85,7 @@ General Public License for more details.
 * Using Ghub in Personal Scripts::
 * Using Ghub in a Package::
 * API::
+* Gitlab Support::
 
 @detailmenu
 --- The Detailed Node Listing ---
@@ -172,6 +173,12 @@ Support for Github Enterprise instances.
 
 @item
 Support for token scope validation.
+
+
+@item
+Support for Gitlab is implemented in the @code{glab.el} library, which is
+maintained in the same repository as @code{ghub.el} but distributed as a
+separate package.
 @end itemize
 
 These features will likely never be implemented in Ghub:
@@ -217,16 +224,6 @@ Once a token has been created a package cannot request new scopes
 that it previously did not need.  I am not quite sure yet whether
 Ghub should support that.  An alternative would be to let packages
 at least invalidate their own tokens.
-
-
-@item
-Other Git forges (Gitlab, Bitbucket@dots{}) are not supported.
-
-Support for other forges will likely be implemented using @strong{other}
-libraries that are very similar to this library.  Whether common
-code will be factored out into a library to be used by all these
-libraries or whether some code duplication is to be preferred, has
-not been decided yet.
 @end itemize
 
 @node Getting Started
@@ -450,6 +447,7 @@ variable named @code{PACKAGE-ghub-token-scopes}.  The doc-string of such
 variables should document what the various scopes are needed for.
 
 To create or edit a token go to @uref{https://github.com/settings/tokens}.
+For Gitlab.com use @uref{https://gitlab.com/profile/personal_access_tokens}.
 
 Finally store the token in a place where Ghub looks for it, as described
 in @ref{How Ghub uses Auth-Source}.
@@ -482,11 +480,19 @@ those three slots, and it does that by using "USERNAME@math{^PACKAGE}" as the
 "login".
 
 Assuming your username is "ziggy",the package is named "stardust", and
-you want to access Github.com an entry in one of the three mentioned
+you want to access @strong{Github.com} an entry in one of the three mentioned
 files would then look like this:
 
 @example
 machine api.github.com login ziggy^stardust password 012345abcdef...
+@end example
+
+Assuming your username is "ziggy",the package is named "stardust", and
+you want to access @strong{Gitlab.com} an entry in one of the three mentioned
+files would then look like this:
+
+@example
+machine gitlab.com/api/v4 login ziggy^stardust password 012345abcdef...
 @end example
 
 @node Using Ghub in Personal Scripts
@@ -703,6 +709,13 @@ If HOST is non-nil, then connect to that Github instance.  This
 defaults to "api.github.com".  When a repository is connected to
 a Github Enterprise instance, then it is better to specify that
 using the Git variable @code{github.host} instead of using this argument.
+
+
+@item
+If FORGE is @code{gitlab}, then connect to Gitlab.com or, depending on
+HOST to another Gitlab instance.  This is only intended for
+internal use.  Instead of using this argument you should use
+function @code{glab-request} and other @code{glab-*} functions.
 @end itemize
 @end defun
 
@@ -917,5 +930,39 @@ Alternatively you can set this variable to a unique value, that will
 then be used to identify the local machine instead of the value
 returned by @code{system-name}.
 @end defvar
+
+@node Gitlab Support
+@chapter Gitlab Support
+
+Support for Gitlab.com and other Gitlab instances is implemented in
+the library @code{glab.el}.  This library is build on top of @code{ghub.el} and is
+maintained in the same repository, but it is distributed as a separate
+package.
+
+When accessing Gitlab.com or another Gitlab instance, use @code{glab-request}
+instead of @code{ghub-request}, @code{glab-get} instead of @code{ghub-request}, etc.
+Likewise use the Git variables in the @code{gitlab} group instead of those in
+the @code{github} group, i.e.  @code{gitlab.user}, @code{gitlab.HOST.user} and @code{gitlab.host}.
+
+The Gitlab API cannot be used to create tokens, so Glab cannot provide
+a setup wizard like Ghub does.  As a consequence if the user makes a
+request and the necessary token cannot be found, then that results in
+an error.
+
+You have to manually create and store the necessary tokens.  Tokens
+can be created at @uref{https://gitlab.com/profile/personal_access_tokens},
+or the equivalent URL for another Gitlab instance.  To store the token
+locally, follow the instructions in @ref{Manually Creating and Storing a Token} and @ref{How Ghub uses Auth-Source}.
+
+Packages can that use Glab, can define @code{PACKAGE-gitlab-token-scopes} for
+documentation purposes.  But unlike @code{PACKAGE-github-token-scopes}, which
+is used by the setup wizard this is optional.
+
+And a random hint: where you would use @code{user/repo} when accessing Github,
+you have to use @code{user%2Frepo} when accessing Gitlab, e.g.:
+
+@lisp
+(glab-get "/projects/python-mode-devs%2Fpython-mode")
+@end lisp
 
 @bye

--- a/glab.el
+++ b/glab.el
@@ -1,0 +1,129 @@
+;;; glab.el --- minuscule client library for the Gitlab API  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2016-2018  Jonas Bernoulli
+
+;; Author: Jonas Bernoulli <jonas@bernoul.li>
+;; Homepage: https://github.com/magit/ghub
+;; Keywords: tools
+;; Package-Requires: ((emacs "24.4") (ghub "2.0"))
+
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; For a copy of the GPL see https://www.gnu.org/licenses/gpl.txt.
+
+;;; Commentary:
+
+;; Ghub is a library that provides basic support for using the Github API
+;; from Emacs packages.  It abstracts access to API resources using only
+;; a handful of functions that are not resource-specific.
+
+;; This library is implemented on top of Ghub.  Unlike Ghub, Glab does
+;; not support the guided creation of tokens because Gitlab lacks the
+;; features that would be necessary to implement that.  Users have to
+;; create tokens through the web interface.
+
+;;; Code:
+
+(require 'ghub)
+
+(defconst glab-default-host "gitlab.com/api/v4")
+
+(cl-defun glab-head (resource &optional params
+                              &key query payload headers
+                              unpaginate noerror reader
+                              username auth host)
+  "Make a `HEAD' request for RESOURCE, with optional query PARAMS.
+Like calling `ghub-request' (which see) with \"HEAD\" as METHOD
+and `gitlab' as FORGE."
+  (ghub-request "HEAD" resource params :forge 'gitlab
+                :query query :payload payload :headers headers
+                :unpaginate unpaginate :noerror noerror :reader reader
+                :username username :auth auth :host host))
+
+(cl-defun glab-get (resource &optional params
+                             &key query payload headers
+                             unpaginate noerror reader
+                             username auth host)
+  "Make a `GET' request for RESOURCE, with optional query PARAMS.
+Like calling `ghub-request' (which see) with \"GET\" as METHOD
+and `gitlab' as FORGE."
+  (ghub-request "GET" resource params :forge 'gitlab
+                :query query :payload payload :headers headers
+                :unpaginate unpaginate :noerror noerror :reader reader
+                :username username :auth auth :host host))
+
+(cl-defun glab-put (resource &optional params
+                             &key query payload headers
+                             unpaginate noerror reader
+                             username auth host)
+  "Make a `PUT' request for RESOURCE, with optional payload PARAMS.
+Like calling `ghub-request' (which see) with \"PUT\" as METHOD
+and `gitlab' as FORGE."
+  (ghub-request "PUT" resource params :forge 'gitlab
+                :query query :payload payload :headers headers
+                :unpaginate unpaginate :noerror noerror :reader reader
+                :username username :auth auth :host host))
+
+(cl-defun glab-post (resource &optional params
+                              &key query payload headers
+                              unpaginate noerror reader
+                              username auth host)
+  "Make a `POST' request for RESOURCE, with optional payload PARAMS.
+Like calling `ghub-request' (which see) with \"POST\" as METHOD
+and `gitlab' as FORGE."
+  (ghub-request "POST" resource params :forge 'gitlab
+                :query query :payload payload :headers headers
+                :unpaginate unpaginate :noerror noerror :reader reader
+                :username username :auth auth :host host))
+
+(cl-defun glab-patch (resource &optional params
+                               &key query payload headers
+                               unpaginate noerror reader
+                               username auth host)
+  "Make a `PATCH' request for RESOURCE, with optional payload PARAMS.
+Like calling `ghub-request' (which see) with \"PATCH\" as METHOD
+and `gitlab' as FORGE."
+  (ghub-request "PATCH" resource params :forge 'gitlab
+                :query query :payload payload :headers headers
+                :unpaginate unpaginate :noerror noerror :reader reader
+                :username username :auth auth :host host))
+
+(cl-defun glab-delete (resource &optional params
+                                &key query payload headers
+                                unpaginate noerror reader
+                                username auth host)
+  "Make a `DELETE' request for RESOURCE, with optional payload PARAMS.
+Like calling `ghub-request' (which see) with \"DELETE\" as METHOD
+and `gitlab' as FORGE."
+  (ghub-request "DELETE" resource params :forge 'gitlab
+                :query query :payload payload :headers headers
+                :unpaginate unpaginate :noerror noerror :reader reader
+                :username username :auth auth :host host))
+
+(cl-defun glab-request (method resource &optional params
+                               &key query payload headers
+                               unpaginate noerror reader
+                               username auth host)
+  "Make a request for RESOURCE and return the response body.
+Like calling `ghub-request' (which see) with `gitlab' as FORGE."
+  (ghub-request method resource params :forge 'gitlab
+                :query query :payload payload :headers headers
+                :unpaginate unpaginate :noerror noerror :reader reader
+                :username username :auth auth :host host))
+
+;;; glab.el ends soon
+(provide 'glab)
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+;;; glab.el ends here


### PR DESCRIPTION
Turns out we can implement `glab.el` on top of an only slightly modified `ghub.el`.

Token creation is not supported because Gitlab does not support that. (If Gitlab did support that, then the changes to `ghub.el` would get more complicated, so I am not all that unhappy about this.)