### PR TITLE
Minor doc fixes

### DIFF
--- a/ghub.el
+++ b/ghub.el
@@ -121,9 +121,9 @@ response headers in this variable.")
                                 silent
                                 callback errorback extra)
   "Make a GraphQL request using GRAPHQL and VARIABLES.
-Return the response as a json-like alist.  Even if the response
+Return the response as a JSON-like alist.  Even if the response
 contains `errors', do not raise an error.  GRAPHQL is a GraphQL
-string.  VARIABLES is a json-like alist.  The other arguments
+string.  VARIABLES is a JSON-like alist.  The other arguments
 behave as for `ghub-request' (which see)."
   (cl-assert (stringp graphql))
   (cl-assert (not (stringp variables)))
@@ -227,7 +227,7 @@ Like calling `ghub-request' (which see) with \"DELETE\" as METHOD."
 
 Also place the response header in `ghub-response-headers'.
 
-METHOD is the http method, given as a string.
+METHOD is the HTTP method, given as a string.
 RESOURCE is the resource to access, given as a string beginning
   with a slash.
 
@@ -260,7 +260,7 @@ If NOERROR is non-nil, then do not raise an error if the request
   return the error payload instead of nil.
 If READER is non-nil, then it is used to read and return from the
   response buffer.  The default is `ghub--read-json-payload'.
-  For the very few resources that do not return json, you might
+  For the very few resources that do not return JSON, you might
   want to use `ghub--decode-payload'.
 
 If USERNAME is non-nil, then make a request on behalf of that

--- a/ghub.el
+++ b/ghub.el
@@ -275,8 +275,8 @@ Each package that uses `ghub' should use its own token. If AUTH
   to identify itself, using a symbol matching its name.
 
   Package authors who find this inconvenient should write a
-  wrapper around this function and possibly for the method
-  specific functions also.
+  wrapper around this function and possibly for the
+  method-specific functions as well.
 
   Some symbols have a special meaning.  `none' means to make an
   unauthorized request.  `basic' means to make a password based

--- a/ghub.el
+++ b/ghub.el
@@ -74,12 +74,12 @@ behalf of some private tool.
 
 By default the only requested scope is `repo' because that is
 sufficient as well as required for most common uses.  This and
-other scopes are documented at https://magit.vc/goto/2e586d36.
+other scopes are documented at URL `https://magit.vc/goto/2e586d36'.
 
 If your private tools need other scopes, then you have to add
 them here *before* creating the token.  Alternatively you can
 edit the scopes of an existing token using the web interface
-at https://github.com/settings/tokens.")
+at URL `https://github.com/settings/tokens'.")
 
 (defvar ghub-override-system-name nil
   "If non-nil, the string used to identify the local machine.

--- a/ghub.el
+++ b/ghub.el
@@ -114,7 +114,7 @@ used instead.")
 (defvar ghub-response-headers nil
   "The headers returned in response to the last request.
 `ghub-request' returns the response body and stores the
-response header in this variable.")
+response headers in this variable.")
 
 (cl-defun ghub-graphql (graphql &optional variables
                                 &key username auth host
@@ -124,7 +124,7 @@ response header in this variable.")
 Return the response as a json-like alist.  Even if the response
 contains `errors', do not raise an error.  GRAPHQL is a GraphQL
 string.  VARIABLES is a json-like alist.  The other arguments
-behave like for `ghub-request' (which see)."
+behave as for `ghub-request' (which see)."
   (cl-assert (stringp graphql))
   (cl-assert (not (stringp variables)))
   (ghub-request "POST" "/graphql" nil :payload
@@ -296,7 +296,7 @@ If HOST is non-nil, then connect to that Github instance.  This
   argument.
 
 If FORGE is `gitlab', then connect to Gitlab.com or, depending
-  on HOST to another Gitlab instance.  This is only intended for
+  on HOST, to another Gitlab instance.  This is only intended for
   internal use.  Instead of using this argument you should use
   function `glab-request' and other `glab-*' functions.
 
@@ -309,7 +309,7 @@ If CALLBACK and/or ERRORBACK is non-nil, then make one or more
 
 Both callbacks are called with four arguments.
   1. For CALLBACK, the combined value of the retrieved pages.
-     For ERRORBACk, the error that occured when retrieving the
+     For ERRORBACK, the error that occured when retrieving the
      last page.
   2. The headers of the last page as an alist.
   3. Status information provided by `url-retrieve'. Its `:error'

--- a/ghub.org
+++ b/ghub.org
@@ -253,9 +253,9 @@ of the doubts that you might have:
   the variable ~ghub-github-token-scopes~ before triggering the wizard
   again.
 
-- Each PACKAGE has to specify the tokens that it needs using a
-  variable named ~PACKAGE-github-token-scopes~.  The doc-string of that
-  variable should document why the various scopes are needed.
+- Each ~PACKAGE~ has to specify the tokens that it needs using a
+  variable named ~PACKAGE-github-token-scopes~.  The doc-string of
+  that variable should document why the various scopes are needed.
 
   The meaning of the various scopes are documented at
   https://magit.vc/goto/f63aeb0a.
@@ -321,9 +321,9 @@ figure out what scopes a package wants, (2) create such a token using
 the web interface and (3) store the token where Ghub expects to find
 it.
 
-A package named PACKAGE has to specify the scopes that it wants in the
-variable named ~PACKAGE-ghub-token-scopes~.  The doc-string of such
-variables should document what the various scopes are needed for.
+A package named ~PACKAGE~ has to specify the scopes that it wants in
+the variable named ~PACKAGE-ghub-token-scopes~.  The doc-string of
+such variables should document what the various scopes are needed for.
 
 To create or edit a token go to https://github.com/settings/tokens.
 For Gitlab.com use https://gitlab.com/profile/personal_access_tokens.
@@ -396,7 +396,7 @@ personal scripts.
   (ghub-get "/user" nil :auth 'foobar)
 #+END_SRC
 
-When you do not specify the AUTH argument, then a request is made on
+When you do not specify the ~AUTH~ argument, then a request is made on
 behalf of the ~ghub~ package itself.  Like for any package that uses
 Ghub, ~ghub~ has to declare what scopes it needs, using, in this case,
 the variable ~ghub-github-token-scopes~.
@@ -417,10 +417,10 @@ of some package to only request access to API scopes that are actually
 needed, which in turn might make it easier for users to trust your
 package not to do unwanted things.
 
-The scopes used by PACKAGE have to be defined using the variable
+The scopes used by ~PACKAGE~ have to be defined using the variable
 ~PACKAGE-github-token-scopes~, and you have to tell ~ghub-request~ on
 behalf of which package a request is being made by passing the symbol
-PACKAGE as the value of its AUTH argument.
+~PACKAGE~ as the value of its ~AUTH~ argument.
 
 #+BEGIN_SRC emacs-lisp
   (ghub-request "GET" "/user" nil :auth 'PACKAGE)
@@ -429,10 +429,10 @@ PACKAGE as the value of its AUTH argument.
 - Variable: PACKAGE-github-token-scopes
 
   This variable defines the token scopes requested by the package
-  named PACKAGE.  The doc-string should explain what the various
-  scopes are needed for to prevent users from giving PACKAGE fewer
+  named ~PACKAGE~.  The doc-string should explain what the various
+  scopes are needed for to prevent users from giving ~PACKAGE~ fewer
   permissions than it absolutely needs and also to give them greater
-  confidence that PACKAGE is only requesting the permissions that it
+  confidence that ~PACKAGE~ is only requesting the permissions that it
   actually needs.
 
   The value of this variable does not necessarily correspond to the
@@ -455,8 +455,8 @@ PACKAGE as the value of its AUTH argument.
   correctly determine the used scopes manually.
 
   Just tell users to run ~M-x ghub-token-scopes~ and to provide the
-  correct values for the HOST, USERNAME and PACKAGE when prompted,
-  and to then post the output.
+  correct values for the ~HOST~, ~USERNAME~ and ~PACKAGE~ when
+  prompted, and to then post the output.
 
   It is to be expected that users will occasionally mess that up so
   this command outputs not only the scopes but also the user input so
@@ -478,17 +478,17 @@ latter is documented at https://developer.github.com/v3.
 
 - Function: ghub-request method resource &optional params &key query payload headers unpaginate noerror reader username auth host callback errorback url value error extra method*
 
-  This function makes a request for RESOURCE using METHOD.  PARAMS,
-  QUERY, PAYLOAD and/or HEADERS are alists holding additional request
-  data.  The response body is returned and the response header is
-  stored in the variable ~ghub-response-headers~.
+  This function makes a request for ~RESOURCE~ using ~METHOD~.
+  ~PARAMS~, ~QUERY~, ~PAYLOAD~ and/or ~HEADERS~ are alists holding
+  additional request data.  The response body is returned and the
+  response header is stored in the variable ~ghub-response-headers~.
 
-  - METHOD is the HTTP method, given as a string.
-  - RESOURCE is the resource to access, given as a string beginning
+  - ~METHOD~ is the HTTP method, given as a string.
+  - ~RESOURCE~ is the resource to access, given as a string beginning
     with a slash.
 
-  - PARAMS, QUERY, PAYLOAD and HEADERS are alists and are used to
-    specify request data.  All these arguments are alists that
+  - ~PARAMS~, ~QUERY~, ~PAYLOAD~ and ~HEADERS~ are alists and are used
+    to specify request data.  All these arguments are alists that
     resemble the JSON expected and returned by the Github API.  The
     keys are symbols and the values stored in the ~cdr~ (not the
     ~cadr~) can be strings, integers, or lists of strings and
@@ -496,89 +496,91 @@ latter is documented at https://developer.github.com/v3.
 
     The Github API documentation is vague on how data has to be
     transmitted and for a particular resource usually just talks about
-    "parameters".  Generally speaking when the METHOD is "HEAD" or
+    "parameters".  Generally speaking when the ~METHOD~ is "HEAD" or
     "GET", then they have to be transmitted as a query, otherwise as a
     payload.
 
-    - Use PARAMS to automatically transmit like QUERY or PAYLOAD would
-      depending on METHOD.
-    - Use QUERY to explicitly transmit data as a query.
-    - Use PAYLOAD to explicitly transmit data as a payload.
-      Instead of an alist, PAYLOAD may also be a string, in which
-      case it gets encoded as UTF-8 but is otherwise transmitted as-is.
-    - Use HEADERS for those rare resources that require that the data
-      is transmitted as headers instead of as a query or payload.
+    - Use ~PARAMS~ to automatically transmit like ~QUERY~ or ~PAYLOAD~
+      would depending on ~METHOD~.
+    - Use ~QUERY~ to explicitly transmit data as a query.
+    - Use ~PAYLOAD~ to explicitly transmit data as a payload.  Instead
+      of an alist, ~PAYLOAD~ may also be a string, in which case it
+      gets encoded as UTF-8 but is otherwise transmitted as-is.
+    - Use ~HEADERS~ for those rare resources that require that the
+      data is transmitted as headers instead of as a query or payload.
       When that is the case, then the Github API documentation usually
       mentions it explicitly.
 
-  - If SILENT is non-nil, then progress reports and the like are not
+  - If ~SILENT~ is non-nil, then progress reports and the like are not
     messaged.
 
-  - If UNPAGINATE is t, then this function make as many requests as
-    necessary to get all values.  If UNPAGINATE is a natural number,
+  - If ~UNPAGINATE~ is t, then this function make as many requests as
+    necessary to get all values.  If ~UNPAGINATE~ is a natural number,
     then it gets at most that many pages.  For any other non-nil value
     it raises an error.
 
-  - If NOERROR is non-nil, then no error is raised if the request
-    fails and ~nil~ is returned instead.  If NOERROR is ~return~, then the
-    error payload is returned instead of ~nil~.
+  - If ~NOERROR~ is non-nil, then no error is raised if the request
+    fails and ~nil~ is returned instead.  If ~NOERROR~ is ~return~,
+    then the error payload is returned instead of ~nil~.
 
-  - If READER is non-nil, then it is used to read and return from the
-    response buffer.  The default is ~ghub--read-json-payload~.  For the
-    very few resources that do not return JSON, you might want to use
-    ~ghub--decode-payload~.
+  - If ~READER~ is non-nil, then it is used to read and return from
+    the response buffer.  The default is ~ghub--read-json-payload~.
+    For the very few resources that do not return JSON, you might want
+    to use ~ghub--decode-payload~.
 
-  - If USERNAME is non-nil, then the request is made on behalf of that
-    user.  It is better to specify the user using the Git variable
-    ~github.user~ for "api.github.com", or ~github.HOST.user~ if
-    connecting to a Github Enterprise instance.
+  - If ~USERNAME~ is non-nil, then the request is made on behalf of
+    that user.  It is better to specify the user using the Git
+    variable ~github.user~ for "api.github.com", or ~github.HOST.user~
+    if connecting to a Github Enterprise instance.
 
-  - Each package that uses Ghub should use its own token.  If AUTH is
-    ~nil~ or unspecified, then the generic ~ghub~ token is used instead.
-    This is only acceptable for personal utilities.  A packages that
-    is distributed to other users should always use this argument to
-    identify itself, using a symbol matching its name.
+  - Each package that uses Ghub should use its own token.  If ~AUTH~
+    is ~nil~ or unspecified, then the generic ~ghub~ token is used
+    instead.  This is only acceptable for personal utilities.  A
+    packages that is distributed to other users should always use this
+    argument to identify itself, using a symbol matching its name.
 
     Package authors who find this inconvenient should write a wrapper
     around this function and possibly for the method-specific
     functions as well.
 
-    Beside ~nil~, some other symbols have a special meaning too.  ~none~
-    means to make an unauthorized request.  ~basic~ means to make a
-    password based request.  If the value is a string, then it is
-    assumed to be a valid token.  ~basic~ and an explicit token string
-    are only intended for internal and debugging uses.
+    Beside ~nil~, some other symbols have a special meaning too.
+    ~none~ means to make an unauthorized request.  ~basic~ means to
+    make a password based request.  If the value is a string, then it
+    is assumed to be a valid token.  ~basic~ and an explicit token
+    string are only intended for internal and debugging uses.
 
-    If AUTH is a package symbol, then the scopes are specified using
-    the variable ~AUTH-github-token-scopes~.  It is an error if that is
-    not specified.  See ~ghub-github-token-scopes~ for an example.
+    If ~AUTH~ is a package symbol, then the scopes are specified using
+    the variable ~AUTH-github-token-scopes~.  It is an error if that
+    is not specified.  See ~ghub-github-token-scopes~ for an example.
 
-  - If HOST is non-nil, then connect to that Github instance.  This
-    defaults to "api.github.com".  When a repository is connected to
-    a Github Enterprise instance, then it is better to specify that
-    using the Git variable ~github.host~ instead of using this argument.
+  - If ~HOST~ is non-nil, then connect to that Github instance.
+    This defaults to "api.github.com".  When a repository is connected
+    to a Github Enterprise instance, then it is better to specify that
+    using the Git variable ~github.host~ instead of using this
+    argument.
 
-  - If FORGE is ~gitlab~, then connect to Gitlab.com or, depending on
-    HOST, to another Gitlab instance.  This is only intended for
+  - If ~FORGE~ is ~gitlab~, then connect to Gitlab.com or, depending
+    on ~HOST~, to another Gitlab instance.  This is only intended for
     internal use.  Instead of using this argument you should use
     function ~glab-request~ and other ~glab-*~ functions.
 
-  - If CALLBACK and/or ERRORBACK is non-nil, then this function makes
-    one or more asynchronous requests and calls CALLBACK or ERRORBACK
-    when finished.  If an error occurred, then it calls ERRORBACK, or
-    if that is ~nil~, then CALLBACK.  When no error occurred then it
-    calls CALLBACK.  When making asynchronous requests, then no errors
-    are signaled, regardless of the value of NOERROR.
+  - If ~CALLBACK~ and/or ~ERRORBACK~ is non-nil, then this function
+    makes one or more asynchronous requests and calls ~CALLBACK~ or
+    ~ERRORBACK~ when finished.  If an error occurred, then it calls
+    ~ERRORBACK~, or if that is ~nil~, then ~CALLBACK~.  When no error
+    occurred then it calls ~CALLBACK~.  When making asynchronous
+    requests, then no errors are signaled, regardless of the value of
+    ~NOERROR~.
 
     Both callbacks are called with four arguments.
 
-    1. For CALLBACK, the combined value of the retrieved pages.
-       For ERRORBACK, the error that occured when retrieving the
+    1. For ~CALLBACK~, the combined value of the retrieved pages.
+       For ~ERRORBACK~, the error that occured when retrieving the
        last page.
     2. The headers of the last page as an alist.
     3. Status information provided by ~url-retrieve~.  Its ~:error~
-       property holds the same information as ERRORBACK's first
-       argument.
+       property holds the same information as the first argument to
+       ~ERRORBACK~.
     4. A ~ghub--req~ struct, which can be passed to ~ghub-continue~
        (which see) to retrieve the next page, if any.
 
@@ -641,8 +643,8 @@ latter is documented at https://developer.github.com/v3.
 
 - Function: ghub-response-link-relations headers
 
-  This function returns an alist of the link relations in HEADERS, or
-  if optional HEADERS is nil, then those in ~ghub-response-headers~.
+  This function returns an alist of the link relations in ~HEADERS~, or
+  if optional ~HEADERS~ is nil, then those in ~ghub-response-headers~.
 
 - Variable: ghub-override-system-name
 
@@ -655,20 +657,20 @@ latter is documented at https://developer.github.com/v3.
 - Variable: PACKAGE-github-token-scopes
 
   Such a variable defines the token scopes requested by the respective
-  package PACKAGE given by the first word in the variable name.  ~ghub~
-  itself is treated like any other package.  Also see [[*Using Ghub in a
-  Package]].
+  package ~PACKAGE~ given by the first word in the variable name.
+  ~ghub~ itself is treated like any other package.  Also see [[*Using
+  Ghub in a Package]].
 
 - Function: ghub-head resource &optional params &key query payload headers unpaginate noerror reader username auth host callback errorback
 - Function: ghub-get resource &optional params &key query payload headers unpaginate noerror reader username auth host callback errorback
 
   These functions are simple wrappers around ~ghub-request~.  Their
   signature is identical to that of the latter, except that they do
-  not have an argument named METHOD.  The HTTP method is instead
+  not have an argument named ~METHOD~.  The HTTP method is instead
   given by the second word in the function name.
 
   As described in the documentation for ~ghub-request~, it depends on
-  the used method whether the value of the PARAMS argument is used
+  the used method whether the value of the ~PARAMS~ argument is used
   as the query or the payload.  For the "HEAD" and "GET" methods it
   is used as the query.
 
@@ -679,11 +681,11 @@ latter is documented at https://developer.github.com/v3.
 
   These functions are simple wrappers around ~ghub-request~.  Their
   signature is identical to that of the latter, except that they do
-  not have an argument named METHOD.  The HTTP method is instead
+  not have an argument named ~METHOD~.  The HTTP method is instead
   given by the second word in the function name.
 
   As described in the documentation for ~ghub-request~, it depends on
-  the used method whether the value of the PARAMS argument is used
+  the used method whether the value of the ~PARAMS~ argument is used
   as the query or the payload.  For the "PUT", "POST", "PATCH" and
   "DELETE" methods it is used as the payload.
 
@@ -703,9 +705,9 @@ latter is documented at https://developer.github.com/v3.
   or until the timeout exceeds.  In the latter case it signals
   ~ghub-error~.
 
-  RESOURCE specifies the resource that this function waits for.
+  ~RESOURCE~ specifies the resource that this function waits for.
 
-  DURATION specifies the maximum number of seconds to wait for,
+  ~DURATION~ specifies the maximum number of seconds to wait for,
   defaulting to 64 seconds.  Emacs will block during that time, but
   the user can abort using ~C-g~.
 
@@ -719,10 +721,10 @@ latter is documented at https://developer.github.com/v3.
 
 - Function: ghub-graphql graphql &optional variables &key username auth host callback
 
-  This function makes a GraphQL request using GRAPHQL and VARIABLES as
-  inputs.  GRAPHQL is a GraphQL string.  VARIABLES is a JSON-like
-  alist.  The other arguments behave as for ~ghub-request~ (which
-  see).
+  This function makes a GraphQL request using ~GRAPHQL~ and
+  ~VARIABLES~ as inputs.  ~GRAPHQL~ is a GraphQL string.  ~VARIABLES~
+  is a JSON-like alist.  The other arguments behave as for
+  ~ghub-request~ (which see).
 
   The response is returned as a JSON-like alist.  Even if the response
   contains ~errors~, this function does not raise an error.
@@ -745,10 +747,11 @@ latter is documented at https://developer.github.com/v3.
   command you can also just repeat the initial request after making
   the desired adjustments — that is easier.)
 
-  This command reads, in order, the HOST (Github instance), the
-  USERNAME, the PACKAGE, and the SCOPES in the minibuffer, providing
-  reasonable default choices.  SCOPES defaults to the scopes that
-  PACKAGE requests using the variable ~PACKAGE-github-token-scopes~.
+  This command reads, in order, the ~HOST~ (Github instance), the
+  ~USERNAME~, the ~PACKAGE~, and the ~SCOPES~ in the minibuffer,
+  providing reasonable default choices.  ~SCOPES~ defaults to the
+  scopes that ~PACKAGE~ requests using the variable
+  ~PACKAGE-github-token-scopes~.
 
 - Command: ghub-token-scopes
 
@@ -779,7 +782,7 @@ local machine, which is done using a lisp variable.
 - Variable: github.HOST.user
 
   This variable serves the same purpose as ~github.user~ but for the
-  Github Enterprise instance identified by HOST.
+  Github Enterprise instance identified by ~HOST~.
 
   The reason why separate variables are used is that this makes it
   possible to set both values globally instead of having to set one of
@@ -809,9 +812,9 @@ local machine, which is done using a lisp variable.
   A token is identified on the respective Github instance (Github.com
   or a Github Enterprise instance) using the pair ~(PACKAGE .
   LOCAL-MACHINE)~, or more precisely the string "Emacs package PACKAGE
-  @ LOCAL-MACHINE".  USERNAME and HOST do not have to be encoded
-  because the token is stored for USERNAME on HOST and cannot be used
-  by another user and/or on another instance.
+  @ LOCAL-MACHINE".  ~USERNAME~ and ~HOST~ do not have to be encoded
+  because the token is stored for ~USERNAME~ on ~HOST~ and cannot be
+  used by another user and/or on another instance.
 
   There is one potential problem though; for any given ~(PACKAGE
   . LOCAL-MACHINE)~ there can only be one token identified by "Emacs

--- a/ghub.org
+++ b/ghub.org
@@ -483,13 +483,13 @@ latter is documented at https://developer.github.com/v3.
   data.  The response body is returned and the response header is
   stored in the variable ~ghub-response-headers~.
 
-  - METHOD is the http method, given as a string.
+  - METHOD is the HTTP method, given as a string.
   - RESOURCE is the resource to access, given as a string beginning
     with a slash.
 
   - PARAMS, QUERY, PAYLOAD and HEADERS are alists and are used to
     specify request data.  All these arguments are alists that
-    resemble the json expected and returned by the Github API.  The
+    resemble the JSON expected and returned by the Github API.  The
     keys are symbols and the values stored in the ~cdr~ (not the
     ~cadr~) can be strings, integers, or lists of strings and
     integers.
@@ -525,7 +525,7 @@ latter is documented at https://developer.github.com/v3.
 
   - If READER is non-nil, then it is used to read and return from the
     response buffer.  The default is ~ghub--read-json-payload~.  For the
-    very few resources that do not return json, you might want to use
+    very few resources that do not return JSON, you might want to use
     ~ghub--decode-payload~.
 
   - If USERNAME is non-nil, then the request is made on behalf of that
@@ -664,7 +664,7 @@ latter is documented at https://developer.github.com/v3.
 
   These functions are simple wrappers around ~ghub-request~.  Their
   signature is identical to that of the latter, except that they do
-  not have an argument named METHOD.  The http method is instead
+  not have an argument named METHOD.  The HTTP method is instead
   given by the second word in the function name.
 
   As described in the documentation for ~ghub-request~, it depends on
@@ -679,7 +679,7 @@ latter is documented at https://developer.github.com/v3.
 
   These functions are simple wrappers around ~ghub-request~.  Their
   signature is identical to that of the latter, except that they do
-  not have an argument named METHOD.  The http method is instead
+  not have an argument named METHOD.  The HTTP method is instead
   given by the second word in the function name.
 
   As described in the documentation for ~ghub-request~, it depends on
@@ -897,7 +897,7 @@ General Public License for more details.
 #  LocalWords:  Gitlab Glab GraphQL LocalWords Makefile NOERROR PARAMS
 #  LocalWords:  SRC UNPAGINATE alist alists api auth authinfo
 #  LocalWords:  backend backends config customizable eval
-#  LocalWords:  featurep ghub github glab gitlab hostname http json
+#  LocalWords:  featurep ghub github glab gitlab hostname HTTP JSON
 #  LocalWords:  mis netrc noerror num params repo src texinfo toc
 #  LocalWords:  unencrypted unpaginate utils ziggy
 

--- a/ghub.org
+++ b/ghub.org
@@ -908,6 +908,8 @@ General Public License for more details.
 # eval: (require 'ox-extra    nil t)
 # eval: (require 'ox-texinfo+ nil t)
 # eval: (and (featurep 'ox-extra) (ox-extras-activate '(ignore-headlines)))
+# fill-column: 70
 # indent-tabs-mode: nil
 # org-src-preserve-indentation: nil
+# sentence-end-double-space: t
 # End:

--- a/ghub.org
+++ b/ghub.org
@@ -70,10 +70,10 @@ Fancier interfaces can be implemented on top of Ghub, and one such
 wrapper — named simply Ghub+ — has already been implemented.  The
 benefit of basing various opinionated interfaces on top of a single
 library that provides only the core functionality is that choosing the
-programming interface does no longer also dictate how access tokens
-are handled.  Users can then use multiple packages that access the
-Github API without having to learn the various incompatible ways
-packages expect the appropriate token to be made available to them.
+programming interface no longer dictates how access tokens are
+handled.  Users can then use multiple packages that access the Github
+API without having to learn the various incompatible ways packages
+expect the appropriate token to be made available to them.
 
 Ghub uses the built-in ~auth-source~ library to store access tokens.
 That library is very flexible and supports multiple backends, which
@@ -90,12 +90,11 @@ of sharing a single token between all packages that rely on it.  That
 means that users cannot configure Ghub once and later start using a
 new package without any additional setup.  But Ghub helps with that.
 
-When the user invokes some command defined in some package and that
-ultimately results in ~ghub-request~ being called and the appropriate
-token is not available yet, then the user is guided through the
-process of creating and storing a new token, and at the end of that
-process the request is carried out as if the token had been available
-to begin with.
+When the user invokes some command that ultimately results in
+~ghub-request~ being called and the appropriate token is not available
+yet, then the user is guided through the process of creating and
+storing a new token, and at the end of that process the request is
+carried out as if the token had been available to begin with.
 
 * Getting Started
 
@@ -420,7 +419,7 @@ package not to do unwanted things.
 
 The scopes used by PACKAGE have to be defined using the variable
 ~PACKAGE-github-token-scopes~, and you have to tell ~ghub-request~ on
-behalf of what package a request is being made by passing the symbol
+behalf of which package a request is being made by passing the symbol
 PACKAGE as the value of its AUTH argument.
 
 #+BEGIN_SRC emacs-lisp
@@ -460,9 +459,9 @@ PACKAGE as the value of its AUTH argument.
   and to then post the output.
 
   It is to be expected that users will occasionally mess that up so
-  this command does not only output the scopes but also the user input
-  so that you can have greater confidence in the validity of the
-  user's answer.
+  this command outputs not only the scopes but also the user input so
+  that you can have greater confidence in the validity of the user's
+  answer.
 
   #+BEGIN_EXAMPLE
     Scopes for USERNAME^PACKAGE@HOST: (SCOPE...)
@@ -491,8 +490,8 @@ latter is documented at https://developer.github.com/v3.
   - PARAMS, QUERY, PAYLOAD and HEADERS are alists and are used to
     specify request data.  All these arguments are alists that
     resemble the json expected and returned by the Github API.  The
-    keys are symbols and the values are stored in the ~cdr~ (not the
-    ~cadr~) and can be strings, integers and lists of strings and
+    keys are symbols and the values stored in the ~cdr~ (not the
+    ~cadr~) can be strings, integers, or lists of strings and
     integers.
 
     The Github API documentation is vague on how data has to be
@@ -541,8 +540,8 @@ latter is documented at https://developer.github.com/v3.
     identify itself, using a symbol matching its name.
 
     Package authors who find this inconvenient should write a wrapper
-    around this function and possibly for the method specific
-    functions also.
+    around this function and possibly for the method-specific
+    functions as well.
 
     Beside ~nil~, some other symbols have a special meaning too.  ~none~
     means to make an unauthorized request.  ~basic~ means to make a
@@ -706,14 +705,14 @@ latter is documented at https://developer.github.com/v3.
 
   RESOURCE specifies the resource that this function waits for.
 
-  DURATION specifies for how many seconds to wait at most, defaulting
-  to 64 seconds.  Emacs will block during that time, but the user can
-  abort using ~C-g~.
+  DURATION specifies the maximum number of seconds to wait for,
+  defaulting to 64 seconds.  Emacs will block during that time, but
+  the user can abort using ~C-g~.
 
-  The first attempt is made immediately and often that will actually
-  succeed.  If not, then another attempt is made after two seconds,
-  and each subsequent attempt is made after waiting as long as we
-  already waited between all preceding attempts combined.
+  The first attempt is made immediately and will often succeed.  If
+  not, then another attempt is made after two seconds, and each
+  subsequent attempt is made after waiting as long as we already
+  waited between all preceding attempts combined.
 
   See ~ghub-request~'s documentation above for information about the
   other arguments.
@@ -747,16 +746,16 @@ latter is documented at https://developer.github.com/v3.
   the desired adjustments — that is easier.)
 
   This command reads, in order, the HOST (Github instance), the
-  USERNAME, the PACKAGE and the SCOPES in the minibuffer, providing
+  USERNAME, the PACKAGE, and the SCOPES in the minibuffer, providing
   reasonable default choices.  SCOPES defaults to the scopes that
   PACKAGE requests using the variable ~PACKAGE-github-token-scopes~.
 
 - Command: ghub-token-scopes
 
   Users are free to give a token access to fewer scopes than what the
-  respective package requested.  That can of course lead to issues and
-  package maintainers have to be able to quickly determine if such a
-  (mis-)configuration is the root cause when users report issues.
+  respective package requested.  That can, of course, lead to issues,
+  and package maintainers have to be able to quickly determine if such
+  a (mis-)configuration is the root cause when users report issues.
 
   This command reads the required values in the minibuffer and then
   shows a message containing these values along with the scopes of the
@@ -818,8 +817,8 @@ local machine, which is done using a lisp variable.
   . LOCAL-MACHINE)` there can only be one token identified by "Emacs
   package PACKAGE @ LOCAL-MACHINE"; Github does not allow multiple
   tokens with the same description because it uses the description as
-  the identifier.  (It could use some hash instead, but alas it does
-  not.)
+  the identifier (it could use some hash instead, but alas it does
+  not).
 
   If you have multiple machines and some of them have the same name,
   then you should probably change that as this is not how things ought

--- a/ghub.org
+++ b/ghub.org
@@ -66,14 +66,14 @@ wide adoption would make life easier for users and maintainers alike,
 because then all packages that talk to the Github API could be
 configured the same way.
 
-Fancier interfaces can implemented on top of Ghub, and one such
+Fancier interfaces can be implemented on top of Ghub, and one such
 wrapper — named simply Ghub+ — has already been implemented.  The
 benefit of basing various opinionated interfaces on top of a single
 library that provides only the core functionality is that choosing the
 programming interface does no longer also dictate how access tokens
 are handled.  Users can then use multiple packages that access the
 Github API without having to learn the various incompatible ways
-packages expects the appropriate token to be made available to them.
+packages expect the appropriate token to be made available to them.
 
 Ghub uses the built-in ~auth-source~ library to store access tokens.
 That library is very flexible and supports multiple backends, which
@@ -81,7 +81,7 @@ means that it is up to the user how secrets are stored.  They can,
 among other things, choose between storing secrets in plain text for
 ease of use, or encrypted for better security.
 
-Previously (as in until this library is widely adapted) it was up to
+Previously (as in until this library is widely adopted) it was up to
 package authors to decide if things should be easy or secure.  (Note
 that ~auth-source~ defaults to "easy" — you have been warned.)
 
@@ -99,7 +99,7 @@ to begin with.
 
 * Getting Started
 
-Each package that uses Ghub uses its own token.  Despite that, changes
+Each package that uses Ghub uses its own token.  Despite that, chances
 are good that after successfully configuring one package you can just
 start using another package pretty much instantly.
 
@@ -113,8 +113,8 @@ However, in some situations some manual configuration is necessary
 *before* using the wizard, or the wizard cannot be used at all:
 
 - If you don't want to use the wizard then you don't have to and can
-  create tokens manually as describe in [[*Manually Creating and Storing
-  a Token]].
+  create tokens manually as described in [[*Manually Creating and
+  Storing a Token]].
 
 - If you want to access Gitlab.com or another Gitlab instance, then
   you have to create the token manually as describe in [[*Manually
@@ -141,9 +141,9 @@ However, in some situations some manual configuration is necessary
   repeat the request to trigger the wizard again.
 
 - The setup wizard should work even if you have enabled two-factor
-  authentication.  However it your Github Enterprise instance enforces
+  authentication.  However if your Github Enterprise instance enforces
   Single Sign-On as an additional security measure, then you are out
-  of luck and have to create the token manually as describe in
+  of luck and have to create the token manually as described in
   [[*Manually Creating and Storing a Token]].
 
 The variables mentioned above — and others — are documented in
@@ -382,7 +382,7 @@ files would then look like this:
 * Using Ghub in Personal Scripts
 
 You can use ~ghub-request~ and its wrapper functions in your personal
-scripts of course.  Unlike when you use Ghub from a package that you
+scripts, of course.  Unlike when you use Ghub from a package that you
 distribute for others to use, you don't have to specify a package in
 personal scripts.
 
@@ -434,7 +434,7 @@ PACKAGE as the value of its AUTH argument.
   scopes are needed for to prevent users from giving PACKAGE fewer
   permissions than it absolutely needs and also to give them greater
   confidence that PACKAGE is only requesting the permissions that it
-  actually need.
+  actually needs.
 
   The value of this variable does not necessarily correspond to the
   scopes that the respective token actually gives access to.  There is
@@ -481,7 +481,7 @@ latter is documented at https://developer.github.com/v3.
 
   This function makes a request for RESOURCE using METHOD.  PARAMS,
   QUERY, PAYLOAD and/or HEADERS are alists holding additional request
-  data.  The response body is returned and the response header in
+  data.  The response body is returned and the response header is
   stored in the variable ~ghub-response-headers~.
 
   - METHOD is the http method, given as a string.
@@ -534,7 +534,7 @@ latter is documented at https://developer.github.com/v3.
     ~github.user~ for "api.github.com", or ~github.HOST.user~ if
     connecting to a Github Enterprise instance.
 
-  - Each package that uses Ghub should use its own token. If AUTH is
+  - Each package that uses Ghub should use its own token.  If AUTH is
     ~nil~ or unspecified, then the generic ~ghub~ token is used instead.
     This is only acceptable for personal utilities.  A packages that
     is distributed to other users should always use this argument to
@@ -560,7 +560,7 @@ latter is documented at https://developer.github.com/v3.
     using the Git variable ~github.host~ instead of using this argument.
 
   - If FORGE is ~gitlab~, then connect to Gitlab.com or, depending on
-    HOST to another Gitlab instance.  This is only intended for
+    HOST, to another Gitlab instance.  This is only intended for
     internal use.  Instead of using this argument you should use
     function ~glab-request~ and other ~glab-*~ functions.
 
@@ -574,10 +574,10 @@ latter is documented at https://developer.github.com/v3.
     Both callbacks are called with four arguments.
 
     1. For CALLBACK, the combined value of the retrieved pages.
-       For ERRORBACk, the error that occured when retrieving the
+       For ERRORBACK, the error that occured when retrieving the
        last page.
     2. The headers of the last page as an alist.
-    3. Status information provided by ~url-retrieve~. Its ~:error~
+    3. Status information provided by ~url-retrieve~.  Its ~:error~
        property holds the same information as ERRORBACK's first
        argument.
     4. A ~ghub--req~ struct, which can be passed to ~ghub-continue~
@@ -722,20 +722,20 @@ latter is documented at https://developer.github.com/v3.
 
   This function makes a GraphQL request using GRAPHQL and VARIABLES as
   inputs.  GRAPHQL is a GraphQL string.  VARIABLES is a JSON-like
-  alist.  The other arguments behave like for `ghub-request' (which
+  alist.  The other arguments behave as for ~ghub-request~ (which
   see).
 
   The response is returned as a JSON-like alist.  Even if the response
-  contains ~errors~, this function does not raise an error.  Likewise
-  cursor-handling too is left to the caller.
+  contains ~errors~, this function does not raise an error.
+  Cursor-handling is likewise left to the caller.
 
 ** Authentication
 
 - Command: ghub-create-token
 
   This command creates a new token using the values it reads from the
-  user and then stores it according to variable ~auth-sources~.  It can
-  also be called non-interactively, but you shouldn't do that
+  user and then stores it according to the variable ~auth-sources~.
+  It can also be called non-interactively, but you shouldn't do that
   yourself.
 
   This is useful if you want to fully setup things before attempting
@@ -746,7 +746,7 @@ latter is documented at https://developer.github.com/v3.
   command you can also just repeat the initial request after making
   the desired adjustments — that is easier.)
 
-  This command reads, in that order, the HOST (Github instance), the
+  This command reads, in order, the HOST (Github instance), the
   USERNAME, the PACKAGE and the SCOPES in the minibuffer, providing
   reasonable default choices.  SCOPES defaults to the scopes that
   PACKAGE requests using the variable ~PACKAGE-github-token-scopes~.
@@ -761,7 +761,7 @@ latter is documented at https://developer.github.com/v3.
   This command reads the required values in the minibuffer and then
   shows a message containing these values along with the scopes of the
   respective token.  It also returns the scopes (only) when called
-  non-interactively. Also see [[*Using Ghub in a Package]].
+  non-interactively.  Also see [[*Using Ghub in a Package]].
 
 ** Configuration Variables
 
@@ -796,15 +796,15 @@ local machine, which is done using a lisp variable.
   Enterprise instance, including those that should actually be
   connected to Github.com.
 
-  When this is undefined, then "api.github.com" is used (define in the
-  constant ~ghub-default-host-host~, which you should never attempt to
+  When this is undefined, then "api.github.com" is used (defined in
+  the constant ~ghub-default-host~, which you should never attempt to
   change.)
 
 - Variable: ghub-override-system-name
 
   Ghub uses a different token for each quadruple `(USERNAME PACKAGE
   HOST LOCAL-MACHINE)`.  Theoretically it could reuse tokens to some
-  extend but that would be more difficult to implement, less flexible,
+  extent but that would be more difficult to implement, less flexible,
   and less secure (though slightly more convenient).
 
   A token is identified on the respective Github instance (Github.com
@@ -816,23 +816,24 @@ local machine, which is done using a lisp variable.
 
   There is one potential problem though; for any given `(PACKAGE
   . LOCAL-MACHINE)` there can only be one token identified by "Emacs
-  package PACKAGE @ LOCAL-MACHINE", Github does not allow multiple
+  package PACKAGE @ LOCAL-MACHINE"; Github does not allow multiple
   tokens with the same description because it uses the description as
   the identifier.  (It could use some hash instead, but alas it does
   not.)
 
   If you have multiple machines and some of them have the same name,
-  then you should probably change that as this is not how thing ought
+  then you should probably change that as this is not how things ought
   to be.  However if you dual-boot, then it might make sense to give
   that machine the same name regardless of what operating system you
   have booted into.
 
   You could use the same token on both operating systems, but setting
   that up might be somewhat difficult because it is not possible to
-  download an existing token from Github.  You could of course locally
-  copy the token, but that is inconvenient and would make it harder to
-  only revoke the token used on your infected Windows installation
-  without also revoking it for your totally safe *BSD installation.
+  download an existing token from Github.  You could, of course,
+  locally copy the token, but that is inconvenient and would make it
+  harder to only revoke the token used on your infected Windows
+  installation without also revoking it for your totally safe *BSD
+  installation.
 
   Alternatively you can set this variable to a unique value, that will
   then be used to identify the local machine instead of the value
@@ -851,7 +852,7 @@ use the Git variables in the ~gitlab~ group instead of those in the
 ~github~ group, i.e.  ~gitlab.user~, ~gitlab.HOST.user~ and ~gitlab.host~.
 
 The Gitlab API cannot be used to create tokens, so Glab cannot provide
-a setup wizard like Ghub does.  As a consequence if the user makes a
+a setup wizard like Ghub does.  As a consequence, if the user makes a
 request and the necessary token cannot be found, then that results in
 an error.
 
@@ -861,9 +862,9 @@ or the equivalent URL for another Gitlab instance.  To store the token
 locally, follow the instructions in [[*Manually Creating and Storing a
 Token]] and [[*How Ghub uses Auth-Source]].
 
-Packages that use Glab, can define ~PACKAGE-gitlab-token-scopes~ for
-documentation purposes.  But unlike ~PACKAGE-github-token-scopes~, which
-is used by the setup wizard this is optional.
+Packages that use Glab can define ~PACKAGE-gitlab-token-scopes~ for
+documentation purposes.  But unlike ~PACKAGE-github-token-scopes~,
+which is used by the setup wizard, this is optional.
 
 And a random hint: where you would use ~user/repo~ when accessing Github,
 you have to use ~user%2Frepo~ when accessing Gitlab, e.g.:

--- a/ghub.org
+++ b/ghub.org
@@ -801,20 +801,20 @@ local machine, which is done using a lisp variable.
 
 - Variable: ghub-override-system-name
 
-  Ghub uses a different token for each quadruple `(USERNAME PACKAGE
-  HOST LOCAL-MACHINE)`.  Theoretically it could reuse tokens to some
+  Ghub uses a different token for each quadruple ~(USERNAME PACKAGE
+  HOST LOCAL-MACHINE)~.  Theoretically it could reuse tokens to some
   extent but that would be more difficult to implement, less flexible,
   and less secure (though slightly more convenient).
 
   A token is identified on the respective Github instance (Github.com
-  or a Github Enterprise instance) using the pair `(PACKAGE .
-  LOCAL-MACHINE)`, or more precisely the string "Emacs package PACKAGE
+  or a Github Enterprise instance) using the pair ~(PACKAGE .
+  LOCAL-MACHINE)~, or more precisely the string "Emacs package PACKAGE
   @ LOCAL-MACHINE".  USERNAME and HOST do not have to be encoded
   because the token is stored for USERNAME on HOST and cannot be used
   by another user and/or on another instance.
 
-  There is one potential problem though; for any given `(PACKAGE
-  . LOCAL-MACHINE)` there can only be one token identified by "Emacs
+  There is one potential problem though; for any given ~(PACKAGE
+  . LOCAL-MACHINE)~ there can only be one token identified by "Emacs
   package PACKAGE @ LOCAL-MACHINE"; Github does not allow multiple
   tokens with the same description because it uses the description as
   the identifier (it could use some hash instead, but alas it does


### PR DESCRIPTION
Commits descriptions:

1. The main part of this PR, fixing actual doc errors/ambiguities.
   The rest of the commits are merely stylistic suggestions.
2. Various suggestions for minor rewording.
3. Attempt to format metasyntactic variables like `(FOO . BAR)` as code, like the built-in Elisp manual does (I haven't exported the Org source so I'm not sure my patch actually works). To see what I mean, compare the formatting in the Ghub Info manual:

   ![ghub](https://user-images.githubusercontent.com/9121222/40328561-af8eab9a-5d3e-11e8-87a7-b296480cf1a2.png)
   with that in the Elisp Info manual:

   ![elisp](https://user-images.githubusercontent.com/9121222/40328622-e2a3c51a-5d3e-11e8-932c-a54dc2a778a4.png)
4. Locally enforce currently implied fill variables in the manual.
5. Consistently write acronyms in upper case (unsure about those `LocalWords` settings).
6. Enable URL hyperlinking in docstrings as per [`(elisp) Documentation Tips`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Documentation-Tips.html).