### PR TITLE
Add support for automatic GraphQL unpagination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ env:
   global:
     - CURL="curl -fsSkL --retry 9 --retry-delay 9"
     - EMACS_BASE=https://github.com/npostavs/emacs-travis/releases/download/bins
+    - GHRAW="https://raw.githubusercontent.com"
   matrix:
-    - EMACS_VERSION=24.4
-    - EMACS_VERSION=24.5
     - EMACS_VERSION=25.1
     - EMACS_VERSION=25.3
     - EMACS_VERSION=26
@@ -14,7 +13,9 @@ env:
   allow_failures:
     - env: EMACS_VERSION=master
 install:
-  - $CURL -o let-alist.el https://elpa.gnu.org/packages/let-alist-1.0.5.el
+  - $CURL -O ${GHRAW}/magnars/dash.el/master/dash.el
+  - $CURL -O ${GHRAW}/vermiculus/graphql.el/master/graphql.el
+  - $CURL -O ${GHRAW}/volrath/treepy.el/master/treepy.el
   - $CURL -O ${EMACS_BASE}/emacs-bin-${EMACS_VERSION}.tar.gz
   - tar -xaf emacs-bin-${EMACS_VERSION}.tar.gz -C /
   - export EMACS=/tmp/emacs/bin/emacs

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ ELS  += gogs.el
 ELS  += buck.el
 ELCS  = $(ELS:.el=.elc)
 
-DEPS  =
+DEPS  = dash
+DEPS += graphql
+DEPS += treepy
 
 VERSION ?= $(shell test -e $(TOP).git && git describe --tags --abbrev=0 | cut -c2-)
 

--- a/ghub-graphql.el
+++ b/ghub-graphql.el
@@ -21,7 +21,13 @@
 
 ;;; Code:
 
+(require 'dash)
 (require 'ghub)
+(require 'graphql)
+(require 'subr-x)
+(require 'treepy)
+
+;;; Api
 
 (cl-defun ghub-graphql (graphql &optional variables
                                 &key username auth host
@@ -59,6 +65,363 @@ behave as for `ghub-request' (which see)."
                 (name  . ,name))
               :username username :auth auth :host host)
     .data.repository.id))
+
+;;; Api (drafts)
+
+(defconst ghub-fetch-repository
+  '(query
+    (repository
+     [(owner $owner String!)
+      (name  $name  String!)]
+     name
+     id
+     createdAt
+     updatedAt
+     nameWithOwner
+     description
+     (defaultBranchRef name)
+     isArchived
+     isFork
+     isLocked
+     isMirror
+     isPrivate
+     hasIssuesEnabled
+     hasWikiEnabled
+     (licenseInfo name)
+     (stargazers totalCount)
+     (watchers totalCount)
+     (issues         [(:edges t)
+                      (:singular issue number)
+                      (orderBy ((field . UPDATED_AT) (direction . DESC)))]
+                     number
+                     state
+                     (author login)
+                     title
+                     createdAt
+                     updatedAt
+                     closedAt
+                     locked
+                     (milestone id)
+                     body
+                     (comments [(:edges t)]
+                               databaseId
+                               (author login)
+	                       createdAt
+	                       updatedAt
+                               body))
+     (labels         [(:edges t)
+                      (:singular label id)]
+                     id
+                     name
+                     color
+                     description)
+     (pullRequests   [(:edges t)
+                      (:singular pullRequest number)
+                      (orderBy ((field . UPDATED_AT) (direction . DESC)))]
+                     number
+                     state
+                     (author login)
+                     title
+                     createdAt
+                     updatedAt
+                     closedAt
+                     mergedAt
+                     locked
+                     maintainerCanModify
+                     isCrossRepository
+                     (milestone id)
+                     body
+                     (baseRef name
+                              (repository nameWithOwner))
+                     (headRef name
+                              (repository (owner login)
+                                          nameWithOwner))
+                     (comments [(:edges t)]
+                               databaseId
+                               (author login)
+                               createdAt
+	                       updatedAt
+	                       body)))))
+
+(cl-defun ghub-fetch-repository (owner name callback
+                                       &optional until
+                                       &key username auth host forge)
+  "Asynchronously fetch forge data about the specified repository.
+Once all data has been collected, CALLBACK is called with the
+data as the only argument."
+  (ghub--graphql-vacuum ghub-fetch-repository
+                        `((owner . ,owner)
+                          (name  . ,name))
+                        callback until
+                        :narrow   '(repository)
+                        :username username
+                        :auth     auth
+                        :host     host
+                        :forge    forge))
+
+(cl-defun ghub-fetch-issue (owner name number callback
+                                  &optional until
+                                  &key username auth host forge)
+  "Asynchronously fetch forge data about the specified issue.
+Once all data has been collected, CALLBACK is called with the
+data as the only argument."
+  (ghub--graphql-vacuum (ghub--graphql-prepare-query
+                         ghub-fetch-repository
+                         `(repository issues (issue . ,number)))
+                        `((owner . ,owner)
+                          (name  . ,name))
+                        callback until
+                        :narrow   '(repository issue)
+                        :username username
+                        :auth     auth
+                        :host     host
+                        :forge    forge))
+
+(cl-defun ghub-fetch-pullreq (owner name number callback
+                                    &optional until
+                                    &key username auth host forge)
+  "Asynchronously fetch forge data about the specified pull-request.
+Once all data has been collected, CALLBACK is called with the
+data as the only argument."
+  (ghub--graphql-vacuum (ghub--graphql-prepare-query
+                         ghub-fetch-repository
+                         `(repository pullRequests (pullRequest . ,number)))
+                        `((owner . ,owner)
+                          (name  . ,name))
+                        callback until
+                        :narrow   '(repository pullRequest)
+                        :username username
+                        :auth     auth
+                        :host     host
+                        :forge    forge))
+
+;;; Internal
+
+(cl-defstruct (ghub--graphql-req
+               (:include ghub--req)
+               (:constructor ghub--make-graphql-req)
+               (:copier nil))
+  (query     nil :read-only t)
+  (variables nil :read-only t)
+  (until     nil :read-only t)
+  (pages     0   :read-only nil))
+
+(cl-defun ghub--graphql-vacuum (query variables callback
+                                      &optional until
+                                      &key narrow username auth host forge)
+  "Make a GraphQL request using QUERY and VARIABLES.
+See Info node `(ghub)GraphQL Support'."
+  (unless host
+    (setq host (ghub--host forge)))
+  (unless (or username (stringp auth) (eq auth 'none))
+    (setq username (ghub--username host forge)))
+  (ghub--graphql-retrieve
+   (ghub--make-graphql-req
+    :url       (url-generic-parse-url (concat "https://" host "/graphql"))
+    :method    "POST"
+    :headers   (ghub--headers nil host auth username forge)
+    :handler   'ghub--graphql-handle-response
+    :query     query
+    :variables variables
+    :until     until
+    :callback  (if narrow
+                   (lambda (data)
+                     (let ((path narrow) key)
+                       (while (setq key (pop path))
+                         (setq data (cdr (assq key data)))))
+                     (funcall callback data))
+                 callback))))
+
+(cl-defun ghub--graphql-retrieve (req &optional lineage cursor)
+  (let ((p (cl-incf (ghub--graphql-req-pages req))))
+    (when (> p 1)
+      (message "Fetching page %s..." p)))
+  (ghub--retrieve
+   (let ((json-false nil))
+     (ghub--encode-payload
+      `((query     . ,(ghub--graphql-encode
+                       (ghub--graphql-prepare-query
+                        (ghub--graphql-req-query req)
+                        lineage cursor)))
+        (variables . ,(ghub--graphql-req-variables req)))))
+   req))
+
+(defun ghub--graphql-prepare-query (query &optional lineage cursor)
+  (when lineage
+    (setq query (ghub--graphql-narrow-query query lineage cursor)))
+  (let ((loc (ghub--alist-zip query))
+        variables)
+    (cl-block nil
+      (while t
+        (let ((node (treepy-node loc)))
+          (when (vectorp node)
+            (let ((alist (cl-coerce node 'list))
+                  vars)
+              (when (assq :edges alist)
+                (push (list 'first 100) vars)
+                (setq loc  (treepy-up loc))
+                (setq node (treepy-node loc))
+                (setq loc  (treepy-replace
+                            loc `(,(car  node)
+                                  ,(cadr node)
+                                  (pageInfo endCursor hasNextPage)
+                                  (edges (node ,@(cddr node))))))
+                (setq loc  (treepy-down loc))
+                (setq loc  (treepy-next loc)))
+              (dolist (elt alist)
+                (cond ((keywordp (car elt)))
+                      ((= (length elt) 3)
+                       (push (list (nth 0 elt)
+                                   (nth 1 elt)) vars)
+                       (push (list (nth 1 elt)
+                                   (nth 2 elt)) variables))
+                      ((= (length elt) 2)
+                       (push elt vars))))
+              (setq loc (treepy-replace loc (cl-coerce vars 'vector))))))
+        (if (treepy-end-p loc)
+            (let ((node (copy-sequence (treepy-node loc))))
+              (when variables
+                (push (cl-coerce variables 'vector)
+                      (cdr node)))
+              (cl-return node))
+          (setq loc (treepy-next loc)))))))
+
+(defun ghub--graphql-handle-response (status req)
+  (let ((buffer (current-buffer)))
+    (unwind-protect
+        (progn
+          (set-buffer-multibyte t)
+          (let* ((headers (ghub--handle-response-headers status req))
+                 (payload (ghub--handle-response-payload req))
+                 (payload (ghub--handle-response-error status payload req))
+                 (err     (plist-get status :error))
+                 (errors  (cdr (assq 'errors payload)))
+                 (errors  (and errors
+                               (cons 'ghub-graphql-error errors)))
+                 (data    (assq 'data payload))
+                 (value   (ghub--req-value req)))
+            (setf (ghub--req-value req) value)
+            (if (or err errors)
+                (if-let ((errorback (ghub--req-errorback req)))
+                    (funcall errorback (or err errors) headers status req)
+                  (ghub--signal-error (or err errors)))
+              (ghub--graphql-walk-response value data req))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(defun ghub--graphql-walk-response (loc data req)
+  (if (not loc)
+      (setf (ghub--req-value req)
+            (setq loc (ghub--alist-zip data)))
+    (setq data (ghub--graphql-narrow-data data (ghub--graphql-lineage loc)))
+    (setf (alist-get 'edges data)
+          (append (alist-get 'edges (treepy-node loc))
+                  (or (alist-get 'edges data)
+                      (error "BUG: Expected new nodes"))))
+    (setq loc (treepy-replace loc data)))
+  (cl-block nil
+    (while t
+      (when (eq (car-safe (treepy-node loc)) 'edges)
+        (setq loc (treepy-up loc))
+        (pcase-let ((`(,key . ,val) (treepy-node loc)))
+          (let-alist val
+            (let* ((cursor (and .pageInfo.hasNextPage
+                                .pageInfo.endCursor))
+                   (until (cdr (assq (intern (format "%s-until" key))
+                                     (ghub--graphql-req-until req))))
+                   (nodes (mapcar #'cdar .edges))
+                   (nodes (if until
+                              (--take-while
+                               (or (string> (cdr (assq 'updatedAt it)) until)
+                                   (setq cursor nil))
+                               nodes)
+                            nodes)))
+              (if cursor
+                  (progn
+                    (setf (ghub--req-value req) loc)
+                    (ghub--graphql-retrieve req
+                                            (ghub--graphql-lineage loc)
+                                            cursor)
+                    (cl-return))
+                (setq loc (treepy-replace loc (cons key nodes))))))))
+      (if (not (treepy-end-p loc))
+          (setq loc (treepy-next loc))
+        (funcall (ghub--req-callback req)
+                 (treepy-root loc))
+        (cl-return)))))
+
+(defun ghub--graphql-lineage (loc)
+  (let (lineage)
+    (while (treepy-up loc)
+      (push (car (treepy-node loc)) lineage)
+      (setq loc (treepy-up loc)))
+    lineage))
+
+(defun ghub--graphql-narrow-data (data lineage)
+  (let (key)
+    (while (setq key (pop lineage))
+      (if (consp (car lineage))
+          (progn (pop lineage)
+                 (setf data (cadr data)))
+        (setq data (assq key (cdr data))))))
+  data)
+
+(defun ghub--graphql-narrow-query (query lineage cursor)
+  (if (consp (car lineage))
+      (let* ((child  (cddr query))
+             (alist  (cl-coerce (cadr query) 'list))
+             (single (cdr (assq :singular alist))))
+        `(,(car single)
+          ,(vector (list (cadr single) (cdr (car lineage))))
+          ,@(if (cdr lineage)
+               (ghub--graphql-narrow-query child (cdr lineage) cursor)
+             child)))
+    (let* ((child  (or (assq (car lineage) (cdr query))
+                       (cl-find-if (lambda (c)
+                                     (and (listp c)
+                                          (vectorp (cadr c))
+                                          (eq (cadr (assq :singular
+                                                          (cl-coerce (cadr c)
+                                                                     'list)))
+                                              (car lineage))))
+                                   (cdr query))))
+           (object (car query))
+           (args   (and (vectorp (cadr query))
+                        (cadr query))))
+      `(,object
+        ,@(and args (list args))
+        ,(cond ((cdr lineage)
+                (ghub--graphql-narrow-query child (cdr lineage) cursor))
+               (cursor
+                `(,(car child)
+                  ,(vconcat `((after ,cursor))
+                            (cadr child))
+                  ,@(cddr child)))
+               (t
+                child))))))
+
+(defun ghub--graphql-encode (g)
+  (if (symbolp g)
+      (symbol-name g)
+    (let* ((object (car g))
+           (args   (and (vectorp (cadr g))
+                        (cl-coerce (cadr g) 'list)))
+           (fields (if args (cddr g) (cdr g))))
+       (concat
+        (graphql--encode-object object)
+        (and args
+             (format " (\n%s)"
+                     (mapconcat (pcase-lambda (`(,key ,val))
+                                  (graphql--encode-argument key val))
+                                args ",\n")))
+        (and fields
+             (format " {\n%s\n}"
+                     (mapconcat #'ghub--graphql-encode fields "\n")))))))
+
+(defun ghub--alist-zip (root)
+  (let ((branchp (lambda (elt) (and (listp elt) (listp (cdr elt)))))
+        (make-node (lambda (_ children) children)))
+    (treepy-zipper branchp #'identity make-node root)))
 
 ;;; _
 (provide 'ghub-graphql)

--- a/ghub-pkg.el
+++ b/ghub-pkg.el
@@ -1,5 +1,7 @@
 (define-package "ghub" "0"
   "Minuscule client libraries for Git forge APIs."
   '((emacs "24.4")
+    (dash "2.14.1")
+    (graphql "0")
     (let-alist "1.0.5")
-    ))
+    (treepy "0.1.0")))

--- a/ghub.org
+++ b/ghub.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Ghub: (ghub).
 #+TEXINFO_DIR_DESC: Minuscule client library for the Github API.
-#+SUBTITLE: for version 2.0.1 (v2.0.1-39-g52e5352+1)
+#+SUBTITLE: for version 2.0.1 (v2.0.1-43-g4d7a092+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -38,7 +38,7 @@ because then all packages that talk to forge APIs could be configured
 the same way.
 
 #+TEXINFO: @noindent
-This manual is for Ghub version 2.0.1 (v2.0.1-39-g52e5352+1).
+This manual is for Ghub version 2.0.1 (v2.0.1-43-g4d7a092+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2017-2018 Jonas Bernoulli <jonas@bernoul.li>
@@ -867,6 +867,127 @@ local machine, which is done using a lisp variable.
   Alternatively you can set this variable to a unique value, that will
   then be used to identify the local machine instead of the value
   returned by ~system-name~.
+
+* GraphQL Support
+
+- Function: ghub-graphql graphql &optional variables &key username auth host callback silent callback errorback value extra
+
+  This function makes a GraphQL request using ~GRAPHQL~ and
+  ~VARIABLES~ as inputs.  ~GRAPHQL~ is a GraphQL string.  ~VARIABLES~
+  is a JSON-like alist.  The other arguments behave as for
+  ~ghub-request~ (which see).
+
+  The response is returned as a JSON-like alist.  Even if the response
+  contains ~errors~, this function does not raise an error.
+  Cursor-handling is likewise left to the caller.
+
+~ghub-graphql~ is a thin convenience wrapper around ~ghub-request~,
+similar to ~ghub-post~ and friends.  While the latter only hard-code
+the value of the ~METHOD~ argument, the former also hard-codes ~RESOURCE~
+and constructs ~PAYLOAD~ from ~GRAPHEQL~ and ~VARIABLES~.  It also drops
+~UNPAGINATE~, ~NOERROR~, ~READER~ (internal functions expect alist-ified
+JSON) and ~FORGE~ (only Github currently supports GraphQL).
+
+~ghub-graphql~ does not account for the fact that pagination works
+differently in GraphQL than it does in REST, so users of this function
+have to deal with that themselves.  Likewise error handling works
+differently and has to be done by the caller too.
+
+An early attempt at implementing automatic unpaginating for GraphQL
+can be found in the ~faithful-graphql~ branch, provided I haven't
+deleted that by now.  On that branch I try to do things as intended by
+the designers of GraphQL, using variables and fragments, and drowning
+in a sea of boilerplate.
+
+The problem with that approach is that it only works for applications
+that fetch specific information on demand and actually want things to
+be paginated.  I am convinced that GraphQL is very nice for web apps.
+
+However the Forge package for which I am implementing all of this has
+very different needs.  It wants to fetch "all the data" and "cache"
+it locally, so that it is available even when there is no internet
+connection.  GraphQL was designed around the idea that you should be
+able to "ask for what you need and get exactly that".  But when that
+boils down to "look, if I persist, then you are going to hand me over
+all the data anyway, so just caught it up already", then things start
+to fall apart.  If Github's GraphQL allowed pagination to be turned
+of completely, then teaching ~ghub-graphql~ about error handling would
+be enough.
+
+But it doesn't and when doing things as intended, then that leads to
+huge amounts of repetitive boilerplate, which is so boring to write
+that doing it without introducing bugs left and right is near
+impossible; so I decided to give up on GraphQL variables, fragments
+and conditions, and instead implement something more powerful, though
+also more opinionated.
+
+- Function: ghub--graphql-vacuum query variables callback &optional until &key narrow username auth host forge
+
+  This function is an opinionated and magic to ~ghub-graphql~.
+  It relies and dark magic to get the job done.
+
+  It makes an initial request using ~QUERY~.  It then looks for
+  paginated edges in the returned data and makes more requests to
+  resolve them.  In order to do so it automatically transforms the
+  initial ~QUERY~ into another query suitable for that particular edge.
+  The data retrieved by subsequent requests is then injected into the
+  data of the original request before that is returned or passed to
+  the callback.  If subsequently retrieved data features new paginated
+  edges, then those are followed recursively.
+
+  The end result is essentially the same as using ~ghub-graphql~, if
+  only it were possible to say "do not paginate anything".  The
+  implementation is much more complicated because it is not possible
+  to do that.
+
+  QUERY is a GraphQL query expressed as a s-expression.  The ~graphql~
+  package is used to turn that into a GraphQL query string, but the
+  format is somewhat different than as documented for that package.
+  Also only a subset of the GraphQL features are supported; fragments
+  for example are not, and magical stuff happens to variables.  This
+  is not documented yet, I am afraid.  Look at existing callers.
+
+  VARIABLES is a JSON-like alist as for ~ghub-graphql~.
+
+  UNTIL is an alist ~((EDGE-until . VALUE)...)~.  When unpaginating ~EDGE~
+  try not to fetch beyond the element whose first field has the value
+  VALUE and remove that element as well as all "lesser" elements from
+  the retrieved data if necessary.  Look at ~forge--pull-repository~ for
+  an example.  This is only useful if you "cache" the response locally
+  and want to avoid fetching data again that you already have.
+
+  Other arguments behave as for ~ghub-graphql~ and ~ghub-request~, more or
+  less.
+
+Using ~ghub--graphql-vacuum~, the following resource specific functions
+are implemented.  These functions are not part of the public API yet
+and are very much subject to change.
+
+- Function: ghub-fetch-repository owner name callback &optional until &key username auth host forge
+
+  This function asynchronously fetches forge data about the specified
+  repository.  Once all data has been collected, ~CALLBACK~ is called
+  with the data as the only argument.
+
+- Function: ghub-fetch-issue owner name callback &optional until &key username auth host forge
+
+  This function asynchronously fetches forge data about the specified
+  issue.  Once all data has been collected, ~CALLBACK~ is called
+  with the data as the only argument.
+
+- Function: ghub-fetch-pullreq owner name callback &optional until &key username auth host forge
+
+  This function asynchronously fetches forge data about the specified
+  pull-request.  Once all data has been collected, ~CALLBACK~ is called
+  with the data as the only argument.
+
+Note that in order to avoid duplication all of these functions base
+their initial query on the query stored in ~ghub-fetch-repository~.  The
+latter two pass that query through ~ghub--graphql-prepare-query~, which
+then used ~ghub--graphql-narrow-query~ to remove parts the caller is not
+interested in.  These two functions are also used internally, when
+unpaginating, but as demonstrated here they can be useful even before
+making an initial request.
 
 * Support for Other Forges
 ** Forge Functions and Variables

--- a/ghub.texi
+++ b/ghub.texi
@@ -30,7 +30,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Ghub User and Developer Manual
-@subtitle for version 2.0.1 (v2.0.1-39-g52e5352+1)
+@subtitle for version 2.0.1 (v2.0.1-43-g4d7a092+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -67,7 +67,7 @@ because then all packages that talk to forge APIs could be configured
 the same way.
 
 @noindent
-This manual is for Ghub version 2.0.1 (v2.0.1-39-g52e5352+1).
+This manual is for Ghub version 2.0.1 (v2.0.1-43-g4d7a092+1).
 
 @quotation
 Copyright (C) 2017-2018 Jonas Bernoulli <jonas@@bernoul.li>
@@ -90,6 +90,7 @@ General Public License for more details.
 * Using Ghub in Personal Scripts::
 * Using Ghub in a Package::
 * API::
+* GraphQL Support::
 * Support for Other Forges::
 
 @detailmenu
@@ -1056,6 +1057,133 @@ Alternatively you can set this variable to a unique value, that will
 then be used to identify the local machine instead of the value
 returned by @code{system-name}.
 @end defvar
+
+@node GraphQL Support
+@chapter GraphQL Support
+
+@defun ghub-graphql graphql &optional variables &key username auth host callback silent callback errorback value extra
+
+This function makes a GraphQL request using @code{GRAPHQL} and
+@code{VARIABLES} as inputs.  @code{GRAPHQL} is a GraphQL string.  @code{VARIABLES}
+is a JSON-like alist.  The other arguments behave as for
+@code{ghub-request} (which see).
+
+The response is returned as a JSON-like alist.  Even if the response
+contains @code{errors}, this function does not raise an error.
+Cursor-handling is likewise left to the caller.
+@end defun
+
+@code{ghub-graphql} is a thin convenience wrapper around @code{ghub-request},
+similar to @code{ghub-post} and friends.  While the latter only hard-code
+the value of the @code{METHOD} argument, the former also hard-codes @code{RESOURCE}
+and constructs @code{PAYLOAD} from @code{GRAPHEQL} and @code{VARIABLES}.  It also drops
+@code{UNPAGINATE}, @code{NOERROR}, @code{READER} (internal functions expect alist-ified
+JSON) and @code{FORGE} (only Github currently supports GraphQL).
+
+@code{ghub-graphql} does not account for the fact that pagination works
+differently in GraphQL than it does in REST, so users of this function
+have to deal with that themselves.  Likewise error handling works
+differently and has to be done by the caller too.
+
+An early attempt at implementing automatic unpaginating for GraphQL
+can be found in the @code{faithful-graphql} branch, provided I haven't
+deleted that by now.  On that branch I try to do things as intended by
+the designers of GraphQL, using variables and fragments, and drowning
+in a sea of boilerplate.
+
+The problem with that approach is that it only works for applications
+that fetch specific information on demand and actually want things to
+be paginated.  I am convinced that GraphQL is very nice for web apps.
+
+However the Forge package for which I am implementing all of this has
+very different needs.  It wants to fetch "all the data" and "cache"
+it locally, so that it is available even when there is no internet
+connection.  GraphQL was designed around the idea that you should be
+able to "ask for what you need and get exactly that".  But when that
+boils down to "look, if I persist, then you are going to hand me over
+all the data anyway, so just caught it up already", then things start
+to fall apart.  If Github's GraphQL allowed pagination to be turned
+of completely, then teaching @code{ghub-graphql} about error handling would
+be enough.
+
+But it doesn't and when doing things as intended, then that leads to
+huge amounts of repetitive boilerplate, which is so boring to write
+that doing it without introducing bugs left and right is near
+impossible; so I decided to give up on GraphQL variables, fragments
+and conditions, and instead implement something more powerful, though
+also more opinionated.
+
+@defun ghub--graphql-vacuum query variables callback &optional until &key narrow username auth host forge
+
+This function is an opinionated and magic to @code{ghub-graphql}.
+It relies and dark magic to get the job done.
+
+It makes an initial request using @code{QUERY}.  It then looks for
+paginated edges in the returned data and makes more requests to
+resolve them.  In order to do so it automatically transforms the
+initial @code{QUERY} into another query suitable for that particular edge.
+The data retrieved by subsequent requests is then injected into the
+data of the original request before that is returned or passed to
+the callback.  If subsequently retrieved data features new paginated
+edges, then those are followed recursively.
+
+The end result is essentially the same as using @code{ghub-graphql}, if
+only it were possible to say "do not paginate anything".  The
+implementation is much more complicated because it is not possible
+to do that.
+
+QUERY is a GraphQL query expressed as a s-expression.  The @code{graphql}
+package is used to turn that into a GraphQL query string, but the
+format is somewhat different than as documented for that package.
+Also only a subset of the GraphQL features are supported; fragments
+for example are not, and magical stuff happens to variables.  This
+is not documented yet, I am afraid.  Look at existing callers.
+
+VARIABLES is a JSON-like alist as for @code{ghub-graphql}.
+
+UNTIL is an alist @code{((EDGE-until . VALUE)...)}.  When unpaginating @code{EDGE}
+try not to fetch beyond the element whose first field has the value
+VALUE and remove that element as well as all "lesser" elements from
+the retrieved data if necessary.  Look at @code{forge--pull-repository} for
+an example.  This is only useful if you "cache" the response locally
+and want to avoid fetching data again that you already have.
+
+Other arguments behave as for @code{ghub-graphql} and @code{ghub-request}, more or
+less.
+@end defun
+
+Using @code{ghub--graphql-vacuum}, the following resource specific functions
+are implemented.  These functions are not part of the public API yet
+and are very much subject to change.
+
+@defun ghub-fetch-repository owner name callback &optional until &key username auth host forge
+
+This function asynchronously fetches forge data about the specified
+repository.  Once all data has been collected, @code{CALLBACK} is called
+with the data as the only argument.
+@end defun
+
+@defun ghub-fetch-issue owner name callback &optional until &key username auth host forge
+
+This function asynchronously fetches forge data about the specified
+issue.  Once all data has been collected, @code{CALLBACK} is called
+with the data as the only argument.
+@end defun
+
+@defun ghub-fetch-pullreq owner name callback &optional until &key username auth host forge
+
+This function asynchronously fetches forge data about the specified
+pull-request.  Once all data has been collected, @code{CALLBACK} is called
+with the data as the only argument.
+@end defun
+
+Note that in order to avoid duplication all of these functions base
+their initial query on the query stored in @code{ghub-fetch-repository}.  The
+latter two pass that query through @code{ghub--graphql-prepare-query}, which
+then used @code{ghub--graphql-narrow-query} to remove parts the caller is not
+interested in.  These two functions are also used internally, when
+unpaginating, but as demonstrated here they can be useful even before
+making an initial request.
 
 @node Support for Other Forges
 @chapter Support for Other Forges


### PR DESCRIPTION
GraphQL was designed around the idea that you should be able to "ask
for what you need and get exactly that".  Unfortunately this does not
cover the "look, if I persist, then you are going to hand me over all
the data anyway, so just caught it up already", which is what Forge
needs.

`ghub--graphql-vacuum` provides a way to unpaginate all cursors in the
returned data without having to write a lot of boilerplate.  Callers
have to provide the query as an s-expression that corresponds to the
root request.  The queries needed to follow cursors in arbitrary
locations within the returned data, are automatically derived from
that query.

`ghub-fetch-repository` fetches information about a repository.
If also serves as an example for how to use `ghub--graphql-vacuum`.

The initial queries used by `ghub-fetch-issue` and
`ghub-fetch-pullreq` are pre-narrowed variants of the initial query of
`ghub-fetch-repository`.  Pre-narrowing is somewhat similar to the use
of fragments, but unlike that, it doesn't result in lots of duplicated
boilerplate and/or lots of variables.

There is very little documentation and everything is still very much
subject to change