### PR TITLE
Require subr-x at compile time

### DIFF
--- a/ghub-graphql.el
+++ b/ghub-graphql.el
@@ -24,8 +24,10 @@
 (require 'dash)
 (require 'ghub)
 (require 'graphql)
-(require 'subr-x)
 (require 'treepy)
+
+(eval-when-compile
+  (require 'subr-x))
 
 ;;; Api
 

--- a/ghub.el
+++ b/ghub.el
@@ -57,7 +57,8 @@
 (require 'url-auth)
 (require 'url-http)
 
-(eval-when-compile (require 'subr-x))
+(eval-when-compile
+  (require 'subr-x))
 
 (defvar url-callback-arguments)
 (defvar url-http-end-of-headers)


### PR DESCRIPTION
If/when-let are macros that can be expanded at compile time rather
than run time