### PR TITLE
fix handling of error from preexisting auth token (#77)

### DIFF
--- a/ghub.el
+++ b/ghub.el
@@ -903,8 +903,9 @@ WARNING: The token will be stored unencrypted in %S.
           ;; simplicity it's better to error out here and ask the user to
           ;; take action. This situation should almost never arise anyway.
           (ghub-http-error
-           (if (string-equal (let-alist (nth 3 ghub--create-token-error)
-                               (car .errors.code))
+           (if (string-equal (let ((err (let-alist (nth 4 ghub--create-token-error)
+                                            (car .errors))))
+                               (let-alist err .code))
                              "already_exists")
                (error "\
 A token named %S already exists on Github. \


### PR DESCRIPTION
If an auth token already exists on GitHub of the name we want to use, the error returned was not being interpreted correctly. A typical response is something like:

```
(ghub-http-error 422 "Unprocessable Entity (Added by DAV)" "/authorizations" ((message . "Validation Failed") (errors ((resource . "OauthAccess") (code . "already_exists") (field . "description"))) (documentation_url . "https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization")))
```

Therefore the error's payload is obtained via `(nth 4 ...)` not `(nth 3
...)`, and then `(let-alist ... .errors)` returns a list not a single error, so we need to use two nested `let-alist` invocations to obtain `.code`.

Fixes #77.