### PR TITLE
Make "forge" argument to `ghub--host` optional

### DIFF
--- a/ghub.el
+++ b/ghub.el
@@ -846,7 +846,7 @@ See https://magit.vc/manual/ghub/Support-for-Other-Forges.html for instructions.
                                user host))))))))
     (if (functionp token) (funcall token) token)))
 
-(cl-defmethod ghub--host (forge)
+(cl-defmethod ghub--host (&optional forge)
   (cl-ecase forge
     ((nil github)
      (or (ignore-errors (car (process-lines "git" "config" "github.host")))


### PR DESCRIPTION
This ensures that upstream libraries such as [`ghub-plus`](https://github.com/vermiculus/ghub-plus) don't need to change to support the `forge` argument, which is handled in the default case anyway.