### PR TITLE
Code review support

### DIFF
--- a/buck.el
+++ b/buck.el
@@ -1,6 +1,6 @@
 ;;; buck.el --- minuscule client library for the Bitbucket API  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2016-2020  Jonas Bernoulli
+;; Copyright (C) 2016-2021  Jonas Bernoulli
 
 ;; Author: Jonas Bernoulli <jonas@bernoul.li>
 ;; Homepage: https://github.com/magit/ghub

--- a/ghub-graphql.el
+++ b/ghub-graphql.el
@@ -1,6 +1,6 @@
 ;;; ghub-graphql.el --- access Github API using GrapthQL  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2016-2020  Jonas Bernoulli
+;; Copyright (C) 2016-2021  Jonas Bernoulli
 
 ;; Author: Jonas Bernoulli <jonas@bernoul.li>
 ;; Homepage: https://github.com/magit/ghub

--- a/ghub-graphql.el
+++ b/ghub-graphql.el
@@ -172,7 +172,8 @@ behave as for `ghub-request' (which see)."
 
 (cl-defun ghub-fetch-repository (owner name callback
                                        &optional until
-                                       &key username auth host forge errorback)
+                                       &key username auth host forge
+                                       headers errorback)
   "Asynchronously fetch forge data about the specified repository.
 Once all data has been collected, CALLBACK is called with the
 data as the only argument."
@@ -185,11 +186,13 @@ data as the only argument."
                         :auth     auth
                         :host     host
                         :forge    forge
+                        :headers  headers
                         :errorback errorback))
 
 (cl-defun ghub-fetch-issue (owner name number callback
                                   &optional until
-                                  &key username auth host forge errorback)
+                                  &key username auth host forge
+                                  headers errorback)
   "Asynchronously fetch forge data about the specified issue.
 Once all data has been collected, CALLBACK is called with the
 data as the only argument."
@@ -204,11 +207,13 @@ data as the only argument."
                         :auth     auth
                         :host     host
                         :forge    forge
+                        :headers  headers
                         :errorback errorback))
 
 (cl-defun ghub-fetch-pullreq (owner name number callback
                                     &optional until
-                                    &key username auth host forge errorback)
+                                    &key username auth host forge
+                                    headers errorback)
   "Asynchronously fetch forge data about the specified pull-request.
 Once all data has been collected, CALLBACK is called with the
 data as the only argument."
@@ -223,6 +228,7 @@ data as the only argument."
                         :auth     auth
                         :host     host
                         :forge    forge
+                        :headers  headers
                         :errorback errorback))
 
 ;;; Internal
@@ -241,7 +247,7 @@ data as the only argument."
 (cl-defun ghub--graphql-vacuum (query variables callback
                                       &optional until
                                       &key narrow username auth host forge
-                                      errorback)
+                                      headers errorback)
   "Make a GraphQL request using QUERY and VARIABLES.
 See Info node `(ghub)GraphQL Support'."
   (unless host
@@ -256,7 +262,7 @@ See Info node `(ghub)GraphQL Support'."
                             (substring host 0 -3)
                           host)))
     :method    "POST"
-    :headers   (ghub--headers nil host auth username forge)
+    :headers   (ghub--headers headers host auth username forge)
     :handler   'ghub--graphql-handle-response
     :query     query
     :variables variables

--- a/ghub.el
+++ b/ghub.el
@@ -1,6 +1,6 @@
 ;;; ghub.el --- minuscule client libraries for Git forge APIs  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2016-2020  Jonas Bernoulli
+;; Copyright (C) 2016-2021  Jonas Bernoulli
 
 ;; Author: Jonas Bernoulli <jonas@bernoul.li>
 ;; Homepage: https://github.com/magit/ghub

--- a/glab.el
+++ b/glab.el
@@ -1,6 +1,6 @@
 ;;; glab.el --- minuscule client library for the Gitlab API  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2016-2020  Jonas Bernoulli
+;; Copyright (C) 2016-2021  Jonas Bernoulli
 
 ;; Author: Jonas Bernoulli <jonas@bernoul.li>
 ;; Homepage: https://github.com/magit/ghub

--- a/gogs.el
+++ b/gogs.el
@@ -1,6 +1,6 @@
 ;;; gogs.el --- minuscule client library for the Gogs API  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2016-2020  Jonas Bernoulli
+;; Copyright (C) 2016-2021  Jonas Bernoulli
 
 ;; Author: Jonas Bernoulli <jonas@bernoul.li>
 ;; Homepage: https://github.com/magit/ghub

--- a/gsexp.el
+++ b/gsexp.el
@@ -1,6 +1,6 @@
 ;;; gsexp.el --- GraphQl as S-expressions  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2016-2020  Jonas Bernoulli
+;; Copyright (C) 2016-2021  Jonas Bernoulli
 
 ;; Author: Jonas Bernoulli <jonas@bernoul.li>
 ;; Homepage: https://github.com/magit/ghub

--- a/gtea.el
+++ b/gtea.el
@@ -1,6 +1,6 @@
 ;;; gtea.el --- minuscule client library for the Gitea API  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2016-2020  Jonas Bernoulli
+;; Copyright (C) 2016-2021  Jonas Bernoulli
 
 ;; Author: Jonas Bernoulli <jonas@bernoul.li>
 ;; Homepage: https://github.com/magit/ghub


### PR DESCRIPTION
These changes allow to fetch more informations on pull-request.
They are needed to have the code-review support for Github:
https://github.com/magit/forge/pull/266

**Max Node Limit Exceeded**
Indeed when I add the `reviewThreads` object in `ghub-fetch-repository`, I received this error from the server:
```
if: peculiar error: 
((type . "MAX_NODE_LIMIT_EXCEEDED") 
 (locations ((line . 232) (column . 3))) 
 (message . "By the time this query traverses to the comments connection, it is requesting up to 1,000,000 possible nodes which exceeds the maximum limit of 500,000."))
```

As workaround I added `ghub-fetch-repository-review-threads` which is minimal in order to fetch only `pullRequests` and avoid the error above.

If you don't mind, I would like your opinion on that.
For Gitlab we don't have this issue since we are sending multiple requests to grab all the informations needed (btw much slower).

However for Github, for the moment I don't know how to handle this case ...