### PR TITLE
Fix URL typo on message

### DIFF
--- a/ghub.el
+++ b/ghub.el
@@ -757,7 +757,7 @@ and call `auth-source-forget+'."
                 (and (not nocreate)
                      (error "\
 Required %s token (%S for %S) does not exist.
-See https://magit.vc/manual/ghub/Getting Started.html
+See https://magit.vc/manual/ghub/Getting-Started.html
 or (info \"(ghub)Getting Started\") for instructions.
 (The setup wizard no longer exists.)"
                             (capitalize (symbol-name (or forge 'github)))


### PR DESCRIPTION
A small typo I've found while trying to set-up forge.

(Nice 404! Funny I'd just found out about Black Books recently and seen that Black episode last week!)