### PR TITLE
ghub--auth: don't add newline to base64 encoded credentials

### DIFF
--- a/ghub.el
+++ b/ghub.el
@@ -723,7 +723,8 @@ and call `auth-source-forget+'."
               (concat "Basic "
                       (base64-encode-string
                        (concat username ":"
-                               (ghub--token host username auth nil forge))))
+                               (ghub--token host username auth nil forge))
+                       t))
             (concat
              (and (not (eq forge 'gitlab)) "token ")
              (encode-coding-string


### PR DESCRIPTION
base64-encode-string may insert newlines in the resulting string.
This will confuse the web server and cause the authentication to fail.
The optional parameter `no-line-break` prevents this.