### PR TITLE
Fix gogs.user documentation

### DIFF
--- a/ghub.org
+++ b/ghub.org
@@ -151,7 +151,7 @@ for these two forges:
 - ~gitea.HOST.user~ specifies the user for the HOST ~gitea~ instance.
 - ~gitea.host~ specifies the ~gitea~ host, unless the HOST argument is
   non-nil
-- ~gogs.user~ is *not* used because no canonical ~gitea~ instance exists.
+- ~gogs.user~ is *not* used because no canonical ~gogs~ instance exists.
 - ~gogs.HOST.user~ specifies the user for the HOST ~gogs~ instance.
 - ~gogs.host~ specifies the ~gogs~ host, unless the HOST argument is
   non-nil

--- a/ghub.texi
+++ b/ghub.texi
@@ -268,7 +268,7 @@ for these two forges:
 non-nil
 
 @item
-@code{gogs.user} is @strong{not} used because no canonical @code{gitea} instance exists.
+@code{gogs.user} is @strong{not} used because no canonical @code{gogs} instance exists.
 
 @item
 @code{gogs.HOST.user} specifies the user for the HOST @code{gogs} instance.


### PR DESCRIPTION
Document that gogs.user isn't used because there is no canonical gogs,
not gitea, instance.