### PR TITLE
Fix more bugs when using json native and json's type flags

### DIFF
--- a/lisp/ghub.el
+++ b/lisp/ghub.el
@@ -343,7 +343,14 @@ Both callbacks are called with four arguments.
     ;; Encode in case caller used (symbol-name 'GET). #35
     :method     (encode-coding-string method 'utf-8)
     :headers    (ghub--headers headers host auth username forge)
-    :handler    'ghub--handle-response
+    :handler    (let ((object-type ghub-json-object-type)
+                      (array-type  ghub-json-array-type)
+                      (use-jansson ghub-json-use-jansson))
+                  (lambda (status req)
+                    (let ((ghub-json-object-type object-type)
+                          (ghub-json-array-type  array-type)
+                          (ghub-json-use-jansson use-jansson))
+                      (ghub--handle-response status req))))
     :unpaginate unpaginate
     :noerror    noerror
     :reader     reader

--- a/lisp/ghub.el
+++ b/lisp/ghub.el
@@ -687,7 +687,10 @@ and https://debbugs.gnu.org/cgi/bugreport.cgi?bug=34341.")
 (defun ghub--json-serialize (object)
   (if (and ghub-json-use-jansson
            (fboundp 'json-serialize))
-      (json-serialize object)
+      (apply #'json-serialize
+             `(,object
+               ,@(and (boundp 'json-false) `(:false-object json-false))
+               ,@(and (boundp 'json-null) `(:null-object json-null))))
     ;; Unfortunately `json-encode' may modify the input.
     ;; See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=40693.
     ;; and https://github.com/magit/forge/issues/267


### PR DESCRIPTION
Sorry that the jansson's native json can cause bugs in other packages that consumes `ghub`.
However, I believe that switching to use the native json parsing has better perf and more conformance than the elisp one.

One example is the case of `(a "a")` is translated to `["a", "a"]` in elisp json (1) and `{"a" : "a"}` in native json (2).
I think that (2) is a more correct interpretation though.

In this change, I've re-introduced the wrapper for `json-{read/encode}` that switches between elisp/native json function when supported.
Those wrappers can be used in place of `json-{read/encode}` throughout this code base.

Also, properly propagate the `ghub-json-{object-type/array-type/use-jasson}` to the callback functions as well.

Let me know if there's unittest that I can add more test cases for these changes