### PR TITLE
docs: quote the git config key

### DIFF
--- a/docs/ghub.org
+++ b/docs/ghub.org
@@ -212,14 +212,14 @@ For example if the API is available at ~https://example.com/api/v3~,
 then you should do this:
 
 #+begin_src shell
-  git config --global github.example.com/api/v3.user USERNAME
+  git config --global 'github.example.com/api/v3.user' 'USERNAME'
 #+end_src
 
 Make sure you use the correct USERNAME for this instance.  It might
 not be the same as on "github.com"!
 
 Doing this only tells Ghub who you are on this host, additionally you
-have to tell Ghub which repository are connected to that forge/host,
+have to tell Ghub which repositories are connected to that forge/host,
 like so:
 
 #+begin_src shell


### PR DESCRIPTION
when setting up ghub enterprise access, the key passed to git config
contains `/`. that must be quoted to make git happy.
also, it doesn't hurt to quote the username too.
