### PR TITLE
Make variable buffer local

### DIFF
--- a/lisp/ghub.el
+++ b/lisp/ghub.el
@@ -984,8 +984,8 @@ the end of the document."
                           (progn
                             (url-http-debug
                              "Spinning for the terminator of last chunk...")
-                            (setq url-http-chunked-last-crlf-missing
-                                  (point)))
+                            (setq-local url-http-chunked-last-crlf-missing
+                                        (point)))
                         (url-http-debug "Removing terminator of last chunk")
                         (delete-region (match-beginning 0) (match-end 0))
                         (when (re-search-forward "^\r?\n" nil t)


### PR DESCRIPTION
As 26faa2b943675107e1664b2fea7174137c473475 is not included I believe that the variable has to be buffer-local'ed before assignment.

I think that setting it globally would basically break `url-http` as, if `url-http-chunked-last-crlf-missing` is ever set, `url-http-chunked-encoding-after-change-function` would never process any payload ever again.

Relates to #81