### PR TITLE
Use symbols for request keys payload

### DIFF
--- a/lisp/ghub-graphql.el
+++ b/lisp/ghub-graphql.el
@@ -54,8 +54,8 @@ behave as for `ghub-request' (which see)."
   (ghub-request "POST"
                 (if (eq forge 'gitlab) "/api/graphql" "/graphql")
                 nil
-                :payload `(("query" . ,graphql)
-                           ,@(and variables `(("variables" ,@variables))))
+                :payload `((query . ,graphql)
+                           ,@(and variables `((variables ,@variables))))
                 :headers headers :silent silent
                 :username username :auth auth :host host :forge forge
                 :callback callback :errorback errorback


### PR DESCRIPTION

`json-serialize` requires the alist keys [to be symbols](https://github.com/emacs-mirror/emacs/blob/85a2eb2c789e7f9c1afa838817b3e9ebecb49da4/src/json.c#L602-L604)

    Alist and plist keys must be symbols; if a key is duplicate, the
    first instance is used.

otherwise it throws an error when ghub uses jansson:
```lisp
(json-encode '(("foo" . "bar")))
;; => "{\"foo\":\"bar\"}"

(json-encode '((foo . "bar")))
;; => "{\"foo\":\"bar\"}"

(json-serialize '(("foo" . "bar")))
;; *** Eval error ***  Wrong type argument: symbolp, "foo"

(json-serialize '((foo . "bar")))
;; "{\"foo\":\"bar\"}"
```

