### PR TITLE
ghub--headers: allow to pass multiple authorization headers

### DIFF
--- a/lisp/ghub.el
+++ b/lisp/ghub.el
@@ -717,7 +717,9 @@ and call `auth-source-forget+'."
       (if (eq auth 'basic)
           (cons (cons "Authorization" (ghub--basic-auth host username))
                 headers)
-        (cons (ghub--auth host auth username forge) headers)))))
+        (let ((auth-data (ghub--auth host auth username forge)))
+          (cond ((listp (cdr auth-data)) (append auth-data headers))
+                (t (cons auth-data headers))))))))
 
 (cl-defgeneric ghub--auth (host auth &optional username forge)
   (unless username


### PR DESCRIPTION
This allows for more customizations on specific (internal) source control tools.