### PR TITLE
Switch to built-in JSON support

### DIFF
--- a/lisp/ghub-graphql.el
+++ b/lisp/ghub-graphql.el
@@ -77,6 +77,21 @@ behave as for `ghub-request' (which see)."
                 :callback callback :errorback errorback
                 :extra extra :value value))
 
+(cl-defun ghub--graphql (graphql
+                         &optional variables
+                         &key username auth host forge
+                         headers
+                         callback errorback)
+  "An experimental and unfinished replacement for `ghub-graphql'."
+  (let ((ghub-graphql-message-progress nil))
+    (ghub--graphql-vacuum graphql variables callback nil
+                          :username  username
+                          :auth      auth
+                          :host      host
+                          :forge     forge
+                          :headers   headers
+                          :errorback errorback)))
+
 ;;; Queries
 
 (cl-defun ghub-graphql-rate-limit (&key username auth host)

--- a/lisp/ghub-graphql.el
+++ b/lisp/ghub-graphql.el
@@ -329,9 +329,6 @@ data as the only argument."
 
 ;;; Internal
 
-(defvar ghub--graphql-debug nil
-  "Whether `ghub--graphql-retrieve' updates the \" *gsexp-encode*\" buffer.")
-
 (cl-defstruct (ghub--graphql-req
                (:include ghub--req)
                (:constructor ghub--make-graphql-req)
@@ -405,7 +402,7 @@ See Info node `(ghub)GraphQL Support'."
          (ghub--graphql-prepare-query
           (ghub--graphql-req-query req)
           lineage cursor)))
-  (when ghub--graphql-debug
+  (when ghub-debug
     (with-current-buffer (get-buffer-create " *gsexp-encode*")
       (erase-buffer)
       (insert (ghub--graphql-req-query-str req))))

--- a/lisp/ghub-graphql.el
+++ b/lisp/ghub-graphql.el
@@ -33,9 +33,9 @@
 
 (eval-when-compile (require 'subr-x))
 
-;;; Api
-
 (define-error 'ghub-graphql-error "GraphQL Error" 'ghub-error)
+
+;;; Settings
 
 (defvar ghub-graphql-message-progress nil
   "Whether to show \"Fetching page N...\" in echo area during requests.
@@ -49,6 +49,8 @@ echo area as well.")
 
 Adjust this value if you're hitting query timeouts against larger
 repositories.")
+
+;;; Mutations
 
 (cl-defun ghub-graphql (graphql
                         &optional variables
@@ -75,25 +77,14 @@ behave as for `ghub-request' (which see)."
                 :callback callback :errorback errorback
                 :extra extra :value value))
 
+;;; Queries
+
 (cl-defun ghub-graphql-rate-limit (&key username auth host)
   "Return rate limit information."
   (let-alist (ghub-graphql
               '(query (rateLimit limit cost remaining resetAt))
               nil :username username :auth auth :host host)
     .data.rateLimit))
-
-(cl-defun ghub--repository-id (owner name &key username auth host)
-  "Return the id of the repository specified by OWNER, NAME and HOST."
-  (let-alist (ghub-graphql
-              '(query (repository [(owner $owner String!)
-                                   (name  $name  String!)]
-                                  id))
-              `((owner . ,owner)
-                (name  . ,name))
-              :username username :auth auth :host host)
-    .data.repository.id))
-
-;;; Api (drafts)
 
 (defconst ghub-fetch-repository-sparse
   '(query
@@ -621,6 +612,17 @@ See Info node `(ghub)GraphQL Support'."
 
 (defun ghub--graphql-pp-response (data)
   (pp-display-expression data "*Pp Eval Output*"))
+
+(cl-defun ghub--repository-id (owner name &key username auth host)
+  "Return the id of the repository specified by OWNER, NAME and HOST."
+  (let-alist (ghub-graphql
+              '(query (repository [(owner $owner String!)
+                                   (name  $name  String!)]
+                                  id))
+              `((owner . ,owner)
+                (name  . ,name))
+              :username username :auth auth :host host)
+    .data.repository.id))
 
 ;;; _
 (provide 'ghub-graphql)

--- a/lisp/ghub-graphql.el
+++ b/lisp/ghub-graphql.el
@@ -476,7 +476,8 @@ See Info node `(ghub)GraphQL Support'."
                 (ghub--graphql-handle-failure
                  req (or err errors) headers status)
               (ghub--graphql-walk-response req (assq 'data payload)))))
-      (when (buffer-live-p buf)
+      (when (and (buffer-live-p buf)
+                 (not (buffer-local-value 'ghub-debug buf)))
         (kill-buffer buf)))))
 
 (defun ghub--graphql-handle-failure (req errors headers status)

--- a/lisp/ghub-graphql.el
+++ b/lisp/ghub-graphql.el
@@ -405,7 +405,10 @@ See Info node `(ghub)GraphQL Support'."
   (when ghub-debug
     (with-current-buffer (get-buffer-create " *gsexp-encode*")
       (erase-buffer)
-      (insert (ghub--graphql-req-query-str req))))
+      (insert (ghub--graphql-req-query-str req) "\n\n")
+      (let ((pos (point)))
+        (insert (ghub--encode-payload (ghub--graphql-req-variables req)) "\n")
+        (ignore-errors (json-pretty-print pos (point))))))
   (ghub--retrieve
    (let ((json-false nil))
      (ghub--encode-payload

--- a/lisp/ghub-graphql.el
+++ b/lisp/ghub-graphql.el
@@ -472,10 +472,14 @@ See Info node `(ghub)GraphQL Support'."
                  (err     (plist-get status :error))
                  (errors  (cdr (assq 'errors payload)))
                  (errors  (and errors (cons 'ghub-graphql-error errors))))
-            (if (or err errors)
-                (ghub--graphql-handle-failure
-                 req (or err errors) headers status)
-              (ghub--graphql-walk-response req (assq 'data payload)))))
+            (cond ((or err errors)
+                   (when (and (not err) ghub-debug)
+                     ;; (pp-display-expression payload "*ghub-graphql error*")
+                     (ignore-errors (json-pretty-print (point) (point-max)))
+                     (pop-to-buffer buf))
+                   (ghub--graphql-handle-failure
+                    req (or err errors) headers status))
+                  ((ghub--graphql-walk-response req (assq 'data payload))))))
       (when (and (buffer-live-p buf)
                  (not (buffer-local-value 'ghub-debug buf)))
         (kill-buffer buf)))))

--- a/lisp/ghub.el
+++ b/lisp/ghub.el
@@ -108,6 +108,9 @@ See https://github.com/magit/ghub/pull/149.")
 (defvar ghub-json-array-type 'list
   "The array type that is used for json payload decoding.")
 
+(defvar ghub-debug nil
+  "Record additional debug information.")
+
 ;;; Request
 ;;;; Object
 

--- a/lisp/ghub.el
+++ b/lisp/ghub.el
@@ -543,7 +543,8 @@ Signal an error if the id cannot be determined."
                              (set-buffer req-buf))
                            (funcall callback value headers status req)))
                         (t value))))))
-      (when (buffer-live-p buf)
+      (when (and (buffer-live-p buf)
+                 (not (buffer-local-value 'ghub-debug buf)))
         (kill-buffer buf)))))
 
 (defun ghub--handle-response-headers (_status req)

--- a/lisp/ghub.el
+++ b/lisp/ghub.el
@@ -625,6 +625,8 @@ Signal an error if the id cannot be determined."
                      (json-null        nil))
                  (json-read-from-string raw)))
            ((json-parse-error json-readtable-error)
+            (pop-to-buffer (current-buffer))
+            (setq-local ghub-debug t)
             `((message
                . ,(if (looking-at "<!DOCTYPE html>")
                       (if (re-search-forward

--- a/lisp/ghub.el
+++ b/lisp/ghub.el
@@ -660,10 +660,7 @@ Signal an error if the id cannot be determined."
                          (json-array-type  ghub-json-array-type)
                          (json-false       nil)
                          (json-null        :null))
-                     ;; Unfortunately `json-encode' may modify the input.
-                     ;; See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=40693.
-                     ;; and https://github.com/magit/forge/issues/267
-                     (json-encode (copy-tree payload))))))
+                     (json-encode payload)))))
          (encode-coding-string payload 'utf-8))))
 
 (defun ghub--url-encode-params (params)

--- a/lisp/ghub.el
+++ b/lisp/ghub.el
@@ -102,12 +102,6 @@ globally because doing that is likely to break other packages
 that use `ghub'.  As a user also do not enable this yet.
 See https://github.com/magit/ghub/pull/149.")
 
-(defvar ghub-json-object-type 'alist
-  "The object type that is used for json payload decoding.")
-
-(defvar ghub-json-array-type 'list
-  "The array type that is used for json payload decoding.")
-
 (defvar ghub-debug nil
   "Record additional debug information.")
 
@@ -614,13 +608,13 @@ Signal an error if the id cannot be determined."
                       (fboundp 'json-parse-string))
                  (json-parse-string
                   raw
-                  :object-type  ghub-json-object-type
-                  :array-type   ghub-json-array-type
+                  :object-type  'alist
+                  :array-type   'list
                   :false-object nil
                   :null-object  nil)
                (require 'json)
-               (let ((json-object-type ghub-json-object-type)
-                     (json-array-type  ghub-json-array-type)
+               (let ((json-object-type 'alist)
+                     (json-array-type  'list)
                      (json-false       nil)
                      (json-null        nil))
                  (json-read-from-string raw)))


### PR DESCRIPTION
Use the built-in native JSON support added in Emacs 30.  In Emacs 29 the built-in support used the `jansson` library, but only if it was built with `--with-json`.
`ghub` already required Emacs 29, now it requires "Emacs 29 with `--with-json`, or Emacs 30.

Support for the old `json.el` interface is dropped.

Decoding should work as before.  When it comes to encoding we inherit a backward incompatible change. Lists, or more accurately "JSON arrays", now have to be specified using Lisp vectors, not Lisp lists.  Adapting to that should be fairly simple. In Forge, for example, this was needed: https://github.com/magit/forge/commit/4247e53b811fbce009612597f5ee214747c692a7.

@wandersoncferreira @vermiculus @vindarel @charignon @xuchunyang @TxGVNN @KarimAziev @arvidj @blahgeek Please update your development branches asap and get ready for the next `ghub` release, scheduled for "monthly releases are on the 1st, though on average I'm about three days late".