### PR TITLE
Use `--` when invoking `git config --get`.

### DIFF
--- a/lisp/ghub.el
+++ b/lisp/ghub.el
@@ -790,7 +790,7 @@ or (info \"(ghub)Getting Started\") for instructions."
     nil))
 
 (defun ghub--git-get (var)
-  (car (process-lines-ignore-status "git" "config" "get" var)))
+  (car (process-lines-ignore-status "git" "config" "--get" var)))
 
 ;;; _
 (provide 'ghub)


### PR DESCRIPTION
I decided to try out Forge today and immediately hit a problem, everything I did gave a similar error:

> Required Github token ("error: key does not contain a section: get^forge" for either "api.github.com" or "api.github.com") does not exist.

This didn't make sense to me because I had set my username:

```
% git config github.user
mogigoma
```

When trying the ghub library directly, without specifying my username, I got the same problem:

```
ELISP> (ghub-request "GET" "/user" nil :forge 'github :host "api.github.com" :auth 'forge)

*** Eval error ***  Required Github token ("error: key does not contain a section: get^forge" for either "api.github.com" or "api.github.com") does not exist.
See https://magit.vc/manual/ghub/Getting-Started.html
or (info "(ghub)Getting Started") for instructions.
```

I dug into the code and found the line I changed in this PR, and tried it directly:

```
ELISP> (process-lines-ignore-status "git" "config" "get" "github.user")
("error: key does not contain a section: get")

ELISP> (process-lines-ignore-status "git" "config" "--get" "github.user")
("mogigoma")
```

The code in question was added 3 days ago, if I understood the logs correctly. This may be a problem with various versions of Git itself, requiring a smarter solution than I wrote. Hope this helps!