### PR TITLE
Remove trailing _html from doc dir URLs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -46,6 +46,7 @@ HTML_FIXUP_CSS    = '/<link rel="stylesheet" type="text\/css" href="\/assets\/pa
 \n<script src="/assets/js/simple-css-switch.js"></script>'
 HTML_FIXUP_ONLOAD = 's/<body lang="en">/<body lang="en" onload="simpleCssSwitch()">/'
 HTML_FIXUP_MENU   = '/<\/body>/i<div id="s-css-s--menu"><\/div>'
+HTML_FIXUP_HREF   = 's% href="\.\./\(.*\)_html/% href="../\1/%'
 
 %.html: %.texi
 	@printf "Generating $@\n"
@@ -57,7 +58,7 @@ HTML_FIXUP_MENU   = '/<\/body>/i<div id="s-css-s--menu"><\/div>'
 	@rm -rf $(PKG)
 	@$(MAKEINFO) --html -o $(PKG)/ $(MANUAL_HTML_ARGS) $<
 	@for f in $$(find $(PKG) -name '*.html') ; do \
-	sed -i -e $(HTML_FIXUP_CSS) -e $(HTML_FIXUP_ONLOAD) -e $(HTML_FIXUP_MENU) $$f ; \
+	sed -i -e $(HTML_FIXUP_CSS) -e $(HTML_FIXUP_ONLOAD) -e $(HTML_FIXUP_MENU) -e $(HTML_FIXUP_HREF) $$f ; \
 	done
 
 %.pdf: %.texi


### PR DESCRIPTION
Fixes a broken link from https://magit.vc/manual/ghub/Creating-a-Token.html to non-existent page https://magit.vc/manual/forge_html/Token-Creation.html.

This is required because `makeinfo` expects linked HTML documents to be in a directory with a name ending `_html` (https://www.gnu.org/software/texinfo/manual/texinfo/texinfo.html#HTML-Splitting-1), but we don’t observe that convention.