### PR TITLE
Update Gitlab API link

### DIFF
--- a/docs/ghub.org
+++ b/docs/ghub.org
@@ -352,7 +352,7 @@ manuals:
   - https://developer.github.com/v4 (GraphQl)
   - https://developer.github.com/v3 (REST)
 - Gitlab:
-  - https://docs.gitlab.com/ee/api/README.html
+  - https://docs.gitlab.com/api/
 - Gitea:
   - https://docs.gitea.io/en-us/api-usage
   - https://try.gitea.io/api/swagger
@@ -717,7 +717,7 @@ making an initial request.
 
   See ~ghub-request~'s documentation above for information about the
   other arguments.
-  
+
 * Notes
 ** Using Ghub in Personal Scripts
 


### PR DESCRIPTION
ATM, the link to Gitlab API in the doc gives me 404, so here I'm correcting it.

Apart from the main link, please note that Gitlab now also has these links:
- REST API: https://docs.gitlab.com/api/rest/
- GraphQL API: https://docs.gitlab.com/api/graphql/

Please let me know if you prefer to have these two instead (similarly to what's been done for github links - e.g. https://magit.vc/manual/ghub/Their-APIs.html )